### PR TITLE
Fix FAQ accordion open/close toggling

### DIFF
--- a/slices/FaqSection/FaqItem.tsx
+++ b/slices/FaqSection/FaqItem.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 
 export const FaqItem = ({ question, answer, open }: any) => {
   const [isOpen, setIsOpen] = useState(open || false);
-  const toggleOpen = () => setIsOpen(!isOpen);
+  const toggleOpen = () => setIsOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <MotionBox
@@ -74,7 +74,6 @@ export const FaqItem = ({ question, answer, open }: any) => {
             height: 0,
             opacity: 0,
             marginTop: "0rem",
-            transitionEnd: { display: "none" },
           },
         }}
         animate={isOpen ? "open" : "closed"}

--- a/slices/FaqSection/FaqItem.tsx
+++ b/slices/FaqSection/FaqItem.tsx
@@ -8,9 +8,16 @@ import { toText } from "@/utils/rich-text";
 import clsx from "clsx";
 import { motion } from "framer-motion";
 import { useState } from "react";
+import type { FaqItem as FaqSliceItem } from "../slice-types";
 
-export const FaqItem = ({ question, answer, open }: any) => {
-  const [isOpen, setIsOpen] = useState(open || false);
+type FaqItemProps = {
+  question: FaqSliceItem["question"];
+  answer: FaqSliceItem["answer"];
+  open?: boolean;
+};
+
+export const FaqItem = ({ question, answer, open = false }: FaqItemProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(open);
   const toggleOpen = () => setIsOpen((prevIsOpen) => !prevIsOpen);
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix FAQ accordion answer panel state so items can be opened and closed repeatedly
- remove the `transitionEnd: { display: "none" }` closed-state lock in `slices/FaqSection/FaqItem.tsx`
- type `FaqItem` props/state to avoid implicit `any` and keep toggling strict

## Testing
- `pnpm type-check` ✅
- `pnpm test:unit` ✅
- `pnpm lint` ⚠️ currently misconfigured in this repo (`next lint` is invalid with Next 16 CLI and is interpreted as a directory argument)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebf5ef79-f50b-4b82-8748-77297220befd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebf5ef79-f50b-4b82-8748-77297220befd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

