### PR TITLE
Refactor FAQ JSON-LD schema generation to page level

### DIFF
--- a/slices/FaqSection/index.tsx
+++ b/slices/FaqSection/index.tsx
@@ -4,9 +4,7 @@ import MotionBox from "@/components/MotionBox";
 import StringText from "@/components/StringText";
 import type { SliceComponentProps } from "@/types/slices";
 import type { FaqSectionSlice } from "../slice-types";
-import { toText, toHtml } from "@/utils/rich-text";
 import clsx from "clsx";
-import Script from "next/script";
 import { FaqItem } from "./FaqItem";
 
 const FaqSection = ({
@@ -33,70 +31,46 @@ const FaqSection = ({
     }
   };
 
-  function buildFaqJsonLd() {
-    const faq = {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      mainEntity: items.map(({ question, answer }) => ({
-        "@type": "Question",
-        name: toText(question),
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: toHtml(answer),
-        },
-      })),
-    };
-    return JSON.stringify(faq);
-  }
-
   const openByDefault = items.length <= 4;
 
   return (
-    <>
-      <Script
-        id={`faq-${section_id || "faq"}-jsonld`}
-        type="application/ld+json"
-        strategy="beforeInteractive"
-        dangerouslySetInnerHTML={{ __html: buildFaqJsonLd() }}
-      />
-      <GridSection
-        id={section_id || slice.type}
-        bottomSpacer={"Medium"}
-        topSpacer={"Medium"}
-        overflowHidden={false}
+    <GridSection
+      id={section_id || slice.type}
+      bottomSpacer={"Medium"}
+      topSpacer={"Medium"}
+      overflowHidden={false}
+    >
+      <MotionBox className="padding-top-md padding-bottom-md gap-y-md padding-left-md padding-right-md col-span-full flex flex-col items-start justify-start lg:col-span-6 lg:col-start-auto lg:row-start-1">
+        {title && (
+          <StringText uppercase bold>
+            {title}
+          </StringText>
+        )}
+        <MotionBox className="flex w-full flex-col items-start justify-start">
+          {items.map((item, index) => (
+            <FaqItem
+              key={index}
+              question={item.question}
+              answer={item.answer}
+              open={openByDefault}
+            />
+          ))}
+        </MotionBox>
+      </MotionBox>
+      <MotionBox
+        className={clsx(
+          "relative col-span-full row-start-1 flex aspect-square overflow-hidden rounded-sm bg-white md:max-h-[calc(100vh-9rem-2rem)] md:rounded-md lg:sticky lg:top-[9.5rem] lg:col-span-6 lg:aspect-auto lg:h-[100vh]",
+          getAssetPosition(asset_position)
+        )}
       >
-        <MotionBox className="padding-top-md padding-bottom-md gap-y-md padding-left-md padding-right-md col-span-full flex flex-col items-start justify-start lg:col-span-6 lg:col-start-auto lg:row-start-1">
-          {title && (
-            <StringText uppercase bold>
-              {title}
-            </StringText>
-          )}
-          <MotionBox className="flex w-full flex-col items-start justify-start">
-            {items.map((item, index) => (
-              <FaqItem
-                key={index}
-                question={item.question}
-                answer={item.answer}
-                open={openByDefault}
-              />
-            ))}
-          </MotionBox>
-        </MotionBox>
-        <MotionBox
-          className={clsx(
-            "relative col-span-full row-start-1 flex aspect-square overflow-hidden rounded-sm bg-white md:max-h-[calc(100vh-9rem-2rem)] md:rounded-md lg:sticky lg:top-[9.5rem] lg:col-span-6 lg:aspect-auto lg:h-[100vh]",
-            getAssetPosition(asset_position)
-          )}
-        >
-          <MediaFrame
-            className="absolute inset-0 h-full w-full overflow-hidden"
-            gallery={gallery}
-            video_url={video_url}
-            media={media}
-          />
-        </MotionBox>
-      </GridSection>
-    </>
+        <MediaFrame
+          className="absolute inset-0 h-full w-full overflow-hidden"
+          gallery={gallery}
+          video_url={video_url}
+          media={media}
+        />
+      </MotionBox>
+    </GridSection>
   );
 };
 

--- a/src/app/(site)/events/[uid]/page.tsx
+++ b/src/app/(site)/events/[uid]/page.tsx
@@ -9,6 +9,7 @@ import {
   DynamicTileFooter,
 } from "@/components/DynamicExports";
 import JsonLdBreadcrumb from "@/components/JsonLdBreadcrumb";
+import JsonLdFaqSlices from "@/components/JsonLdFaqSlices";
 import { eventPages, eventPageUids } from "./content";
 
 export const revalidate = false;
@@ -27,6 +28,7 @@ export default async function Page({
 
   return (
     <Layout page={page} settings={settings} navigation={navigation}>
+      <JsonLdFaqSlices slices={slices} />
       <JsonLdBreadcrumb
         crumbs={[
           { name: "Home", url: "https://thegrandlb.com" },

--- a/src/app/(site)/events/page.tsx
+++ b/src/app/(site)/events/page.tsx
@@ -1,6 +1,7 @@
 import CtaFooter from "@/components/CtaFooter";
 import { DynamicSliceZone } from "@/components/DynamicExports";
 import GridBase from "@/components/grid-index/GridBase";
+import JsonLdFaqSlices from "@/components/JsonLdFaqSlices";
 import JsonLdVideo from "@/components/JsonLdVideo";
 import { getEventIndexLayout } from "@/components/grid-index/utils";
 import HeroCategoryPage from "@/components/HeroCategoryPage";
@@ -30,6 +31,7 @@ export default async function Page() {
 
   return (
     <Layout page={eventIndexPage} settings={settings} navigation={navigation}>
+      <JsonLdFaqSlices slices={slices} />
       <JsonLdVideo
         name="Events at The Grand LB Long Beach — Weddings, Corporate & Celebrations"
         description="The Grand Long Beach hosts weddings, quinceañeras, corporate events, galas, and private celebrations. 7 indoor and outdoor spaces for 40–675 guests. 20 min from LAX."

--- a/src/app/(site)/menus/page.tsx
+++ b/src/app/(site)/menus/page.tsx
@@ -1,5 +1,6 @@
 import { DynamicCtaFooter, DynamicSliceZone } from "@/components/DynamicExports";
 import HeroCategoryPage from "@/components/HeroCategoryPage";
+import JsonLdFaqSlices from "@/components/JsonLdFaqSlices";
 import Layout from "@/components/Layout";
 import { getExtra } from "@/services/get-extra";
 import { menuIndexPage } from "./content";
@@ -12,6 +13,7 @@ export default async function Page() {
 
   return (
     <Layout page={menuIndexPage} settings={settings} navigation={navigation} hidePageUid>
+      <JsonLdFaqSlices slices={slices} />
       <HeroCategoryPage
         headline={title}
         gallery={gallery}

--- a/src/app/(site)/tour/[uid]/page.tsx
+++ b/src/app/(site)/tour/[uid]/page.tsx
@@ -2,6 +2,7 @@ import CtaFooter from "@/components/CtaFooter";
 import { DynamicSliceZone } from "@/components/DynamicExports";
 import HeroDetailPage from "@/components/HeroDetailPage";
 import JsonLdBreadcrumb from "@/components/JsonLdBreadcrumb";
+import JsonLdFaqSlices from "@/components/JsonLdFaqSlices";
 import JsonLdVideo from "@/components/JsonLdVideo";
 import TileFooter from "@/components/TileFooter";
 import { getExtra } from "@/services/get-extra";
@@ -66,6 +67,7 @@ export default async function Page({
 
   return (
     <Layout page={page} settings={settings} navigation={navigation}>
+      <JsonLdFaqSlices slices={slices} />
       {video_url && thumbnailUrl && (
         <JsonLdVideo
           name={metaTitle ?? `${headline} — Video Tour`}

--- a/src/components/JsonLdFaqSlices.tsx
+++ b/src/components/JsonLdFaqSlices.tsx
@@ -1,0 +1,42 @@
+import type { Slice } from "content/types";
+import { toText } from "@/utils/rich-text";
+
+interface FaqItem {
+  question: unknown;
+  answer: unknown;
+}
+
+export default function JsonLdFaqSlices({ slices }: { slices: Slice[] }) {
+  const questions = slices
+    .filter((slice) => slice.type === "faq_section")
+    .flatMap((slice) => {
+      const items = (slice.items ?? []) as FaqItem[];
+      return items.map((item) => ({
+        question: toText(item.question),
+        answer: toText(item.answer),
+      }));
+    })
+    .filter(({ question }) => question.length > 0);
+
+  if (!questions.length) return null;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: questions.map(({ question, answer }) => ({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer,
+      },
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
Refactored FAQ schema markup generation from individual FAQ section components to a centralized, page-level component. This improves maintainability and ensures consistent JSON-LD output across all pages containing FAQ sections.

## Key Changes
- **Removed inline JSON-LD generation**: Deleted `buildFaqJsonLd()` function and `<Script>` tag from `FaqSection` component
- **Created centralized component**: Added new `JsonLdFaqSlices` component that aggregates FAQ data from all FAQ section slices on a page and generates a single JSON-LD schema
- **Updated imports**: Removed unused imports (`toHtml`, `Script`) from `FaqSection`
- **Integrated into pages**: Added `<JsonLdFaqSlices>` component to multiple page templates:
  - `src/app/(site)/events/[uid]/page.tsx`
  - `src/app/(site)/events/page.tsx`
  - `src/app/(site)/menus/page.tsx`
  - `src/app/(site)/tour/[uid]/page.tsx`

## Implementation Details
- `JsonLdFaqSlices` filters slices by type `"faq_section"` and flattens all FAQ items into a single FAQPage schema
- Uses `toText()` utility to convert rich text fields to plain text for schema compatibility
- Filters out empty questions to avoid invalid schema entries
- Returns `null` if no valid questions are found (no unnecessary script tags)
- Maintains the same schema structure as the original implementation but consolidates multiple FAQ sections into one schema per page

https://claude.ai/code/session_018LxS5esiaxDGXrmfzkxHUP