### PR TITLE
Refresh venue videos, posters, and event imagery

### DIFF
--- a/content/shared.constants.ts
+++ b/content/shared.constants.ts
@@ -565,7 +565,7 @@ export const ctaFooter: SharedDoc | null = {
     headline: "Moments \nStart \nHere",
     video_media: null,
     video_url:
-      "https://cdn.thegrandlb.com/cd461232-bc21-4a37-99f3-1fe75274d9f5-footer-peak-15s-281-29-final.mp4",
+      "https://cdn.thegrandlb.com/Footer%20Peak%2015s.mp4",
     media: {
       dimensions: {
         width: 3840,
@@ -573,7 +573,7 @@ export const ctaFooter: SharedDoc | null = {
       },
       alt: "Evening exterior with palms and illuminated entry (footer mood).",
       copyright: null,
-      url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/9c4a00e5-743d-41fc-f500-8e35b371b000/public",
+      url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/99a125f0-0ddb-4c07-419c-355102756200/public",
       id: "ZNRzHxAAACcAlv4o",
       edit: {
         x: 0,

--- a/src/app/(site)/content.ts
+++ b/src/app/(site)/content.ts
@@ -18,14 +18,14 @@ export const homePage: PageDoc = {
         headline: "Where Moments Become Memories",
         video_media: null,
         video_url:
-          "https://cdn.thegrandlb.com/7cff637b-d646-493b-9e81-06266373f84c-homepage-60s-final.mp4",
+          "https://cdn.thegrandlb.com/Homepage%2060s%20v2.mp4",
         media: {
           dimensions: {
             width: 3840,
             height: 2160,
           },
           alt: "Twilight exterior of the venue with palms and dramatic sky.",
-          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/b41a724a-b3ad-40ae-57df-98a1b8ce3400/public",
+          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/7bc9937a-e01f-4c64-ca20-ad0b7afc2600/public",
         },
         primary_action: "Make an Inquiry",
         primary_action_link: {
@@ -418,14 +418,14 @@ export const homePage: PageDoc = {
         section_id: "locale",
         video_media: null,
         video_url:
-          "https://cdn.thegrandlb.com/2a63ded8-77f1-4838-ab41-da32d6e887df-community-section-30s-final.mp4",
+          "https://cdn.thegrandlb.com/Community%20Section%2030s.mp4",
         media: {
           dimensions: {
             width: 3840,
             height: 2160,
           },
           alt: "Aerial twilight over the venue block and adjacent streets.",
-          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/52b8ff11-1b88-41c1-72e8-512662e19700/public",
+          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/54f82582-be9c-4198-39d6-e19d09e4e600/public",
         },
         title: "Family-owned and rooted.",
         description:

--- a/src/app/(site)/events/[uid]/graduation-parties.content.ts
+++ b/src/app/(site)/events/[uid]/graduation-parties.content.ts
@@ -16,9 +16,9 @@ export const graduationPartiesPage: PageDoc = {
         type: "image_section",
         video_media: null,
         media: {
-          dimensions: { width: 3696, height: 2772 },
-          alt: "Grand Ballroom with stage, dance floor, and pink uplighting.",
-          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/3562cb12-8916-4107-ba62-834da911cb00/public",
+          dimensions: { width: 1152, height: 768 },
+          alt: "Grand Ballroom theater setup with coffered ceiling, ring chandeliers, and tables below.",
+          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/6e4c12c4-0822-4a4a-d16b-ffa9e6546b00/public",
         },
         bottom_spacer: "None",
       },
@@ -104,6 +104,15 @@ export const graduationPartiesPage: PageDoc = {
         gallery: {
           data: {
             gallery_items: [
+              {
+                link: null,
+                video_media: null,
+                media: {
+                  dimensions: { width: 512, height: 768 },
+                  alt: "Outdoor buffet service with a staff member plating for a guest among palms.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/36b6a98a-be6a-4b19-6ebe-7b985e62fe00/public",
+                },
+              },
               {
                 link: null,
                 video_media: null,

--- a/src/app/(site)/events/[uid]/indian-weddings.content.ts
+++ b/src/app/(site)/events/[uid]/indian-weddings.content.ts
@@ -16,9 +16,9 @@ export const indianWeddingsPage: PageDoc = {
         type: "image_section",
         video_media: null,
         media: {
-          dimensions: { width: 2816, height: 1826 },
-          alt: "Grand Ballroom with ornate ceiling, crystal chandeliers, formal rounds.",
-          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ba00e56c-e108-4405-26e1-f16ba5b35c00/public",
+          dimensions: { width: 1152, height: 768 },
+          alt: "Grand Ballroom social setup with round tables, blush chair sashes, and pink uplighting.",
+          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ef8c6b56-c2c2-47c6-8e7d-0334a67b2e00/public",
         },
         bottom_spacer: "None",
       },
@@ -132,9 +132,9 @@ export const indianWeddingsPage: PageDoc = {
                 link: null,
                 video_media: null,
                 media: {
-                  dimensions: { width: 2464, height: 1848 },
-                  alt: "Grand Ballroom with ornate ceiling, crystal chandeliers, formal rounds.",
-                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ba00e56c-e108-4405-26e1-f16ba5b35c00/public",
+                  dimensions: { width: 1152, height: 768 },
+                  alt: "Grand Ballroom set with round tables, peach chair sashes, and a draped floral backdrop.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/3517d7dc-7dfb-4b3b-9158-1326cb29fa00/public",
                 },
               },
               {

--- a/src/app/(site)/events/[uid]/milestones.content.ts
+++ b/src/app/(site)/events/[uid]/milestones.content.ts
@@ -130,6 +130,18 @@ export const milestonesPage: PageDoc = {
                 video_media: null,
                 media: {
                   dimensions: {
+                    width: 512,
+                    height: 768,
+                  },
+                  alt: "Bartender pouring a fresh margarita at the outdoor bar.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/5a7146e9-4920-4964-1de3-347f1940cc00/public",
+                },
+              },
+              {
+                link: null,
+                video_media: null,
+                media: {
+                  dimensions: {
                     width: 2464,
                     height: 1848,
                   },

--- a/src/app/(site)/events/[uid]/quinces.content.ts
+++ b/src/app/(site)/events/[uid]/quinces.content.ts
@@ -17,11 +17,11 @@ export const quincesPage: PageDoc = {
         video_media: null,
         media: {
           dimensions: {
-            width: 2816,
-            height: 1826,
+            width: 1152,
+            height: 768,
           },
-          alt: "Ballroom with pink uplighting, dance floor, and DJ booth.",
-          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/39670f24-73de-4ddb-91c8-b992f36ccd00/public",
+          alt: "Quinceañera sweetheart table with lush florals, pink and peach drapery, and gold accents.",
+          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/5df18e9d-af7b-41cc-4869-1cd2f6122f00/public",
         },
         bottom_spacer: "None",
       },
@@ -149,16 +149,42 @@ export const quincesPage: PageDoc = {
           data: {
             gallery_items: [
               {
+                caption: "Ceremony Backdrop",
+                link: null,
+                video_media: null,
+                media: {
+                  dimensions: {
+                    width: 512,
+                    height: 768,
+                  },
+                  alt: "Woven circular backdrop with peach floral arrangements and a tufted settee.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/83ca5e7d-0501-4563-f725-77b1c88c8800/public",
+                },
+              },
+              {
+                caption: "Reception Details",
+                link: null,
+                video_media: null,
+                media: {
+                  dimensions: {
+                    width: 512,
+                    height: 768,
+                  },
+                  alt: "Gold chiavari chairs with coral sashes and elegant place settings.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ed2a0cbd-b79e-4d3b-49cc-1bbe288b0f00/public",
+                },
+              },
+              {
                 caption: "The Grand Ballroom",
                 link: null,
                 video_media: null,
                 media: {
                   dimensions: {
-                    width: 2464,
-                    height: 1848,
+                    width: 1152,
+                    height: 768,
                   },
-                  alt: "Grand Ballroom with ornate ceiling, crystal chandeliers, formal rounds.",
-                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ba00e56c-e108-4405-26e1-f16ba5b35c00/public",
+                  alt: "Grand Ballroom set with round tables, peach chair sashes, and a draped floral backdrop.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/3517d7dc-7dfb-4b3b-9158-1326cb29fa00/public",
                 },
               },
               {

--- a/src/app/(site)/events/[uid]/weddings.content.ts
+++ b/src/app/(site)/events/[uid]/weddings.content.ts
@@ -123,6 +123,18 @@ export const weddingsPage: PageDoc = {
                 video_media: null,
                 media: {
                   dimensions: {
+                    width: 1152,
+                    height: 768,
+                  },
+                  alt: "Sweetheart table with lush florals, pink and peach drapery, and gold accents.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/5df18e9d-af7b-41cc-4869-1cd2f6122f00/public",
+                },
+              },
+              {
+                link: null,
+                video_media: null,
+                media: {
+                  dimensions: {
                     width: 2466,
                     height: 1850,
                   },

--- a/src/app/(site)/events/content.ts
+++ b/src/app/(site)/events/content.ts
@@ -7,14 +7,14 @@ export const eventIndexPage: PageDoc = {
   data: {
     title: "Your Grand Moment",
     video_url:
-      "https://cdn.thegrandlb.com/9e5d872e-81ca-46e2-93e4-7d952055014c-events-index-15s-final.mp4",
+      "https://cdn.thegrandlb.com/Events%20Index%2015s.mp4",
     media: {
       dimensions: {
         width: 3840,
         height: 2160,
       },
       alt: "Elegant ballroom interior with rounds, chandeliers, soft uplighting.",
-      url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/cfe41bb3-f218-430d-868d-99feb6668300/public",
+      url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/fb5211c2-b998-4c97-3a38-2d565addb600/public",
     },
     headline: "No matter your thing, we're here for you.",
     body: "Every occasion deserves a personalized touch. Our seven indoor and outdoor event spaces in Long Beach accommodate 40 to 675 guests—flexible enough for weddings, quinceañeras, corporate conferences, and everything in between.",
@@ -253,11 +253,11 @@ export const eventIndexPage: PageDoc = {
                 video_media: null,
                 media: {
                   dimensions: {
-                    width: 2464,
-                    height: 1848,
+                    width: 1152,
+                    height: 768,
                   },
-                  alt: "Grand Ballroom with ornate ceiling, crystal chandeliers, formal rounds.",
-                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ba00e56c-e108-4405-26e1-f16ba5b35c00/public",
+                  alt: "Grand Ballroom set with round tables, peach chair sashes, and a draped floral backdrop.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/3517d7dc-7dfb-4b3b-9158-1326cb29fa00/public",
                 },
               },
               {
@@ -292,11 +292,11 @@ export const eventIndexPage: PageDoc = {
                 video_media: null,
                 media: {
                   dimensions: {
-                    width: 1848,
-                    height: 2464,
+                    width: 512,
+                    height: 768,
                   },
-                  alt: "Grand Ballroom vertical shot: dramatic ceiling, chandeliers, long perspective toward stage.",
-                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/0061dc98-91d8-48c7-a03c-391748748a00/public",
+                  alt: "Grand Ballroom set with round tables, blush chair sashes, and place settings under ring chandeliers.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/710eb74f-1fce-4e42-89b6-2d41e2643e00/public",
                 },
               },
               {

--- a/src/app/(site)/events/page.tsx
+++ b/src/app/(site)/events/page.tsx
@@ -35,8 +35,8 @@ export default async function Page() {
       <JsonLdVideo
         name="Events at The Grand LB Long Beach — Weddings, Corporate & Celebrations"
         description="The Grand Long Beach hosts weddings, quinceañeras, corporate events, galas, and private celebrations. 7 indoor and outdoor spaces for 40–675 guests. 20 min from LAX."
-        thumbnailUrl="https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/856df71a-3832-4963-6cc1-1fc9c6115c00/public"
-        contentUrl="https://cdn.thegrandlb.com/9e5d872e-81ca-46e2-93e4-7d952055014c-events-index-15s-final.mp4"
+        thumbnailUrl="https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/fb5211c2-b998-4c97-3a38-2d565addb600/public"
+        contentUrl="https://cdn.thegrandlb.com/Events%20Index%2015s.mp4"
         uploadDate="2024-06-01T00:00:00+00:00"
         duration="PT15S"
       />

--- a/src/app/(site)/faq/content.ts
+++ b/src/app/(site)/faq/content.ts
@@ -17,9 +17,9 @@ export const faqPage: PageDoc = {
         section_id: "venue",
         title: "Venue & Spaces",
         media: {
-          dimensions: { width: 2464, height: 1848 },
-          alt: "Grand Ballroom with ornate ceiling, crystal chandeliers, formal rounds.",
-          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ba00e56c-e108-4405-26e1-f16ba5b35c00/public",
+          dimensions: { width: 1152, height: 768 },
+          alt: "Grand Ballroom social setup with round tables, blush chair sashes, and pink uplighting.",
+          url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ef8c6b56-c2c2-47c6-8e7d-0334a67b2e00/public",
         },
         asset_position: true,
         items: [

--- a/src/app/(site)/menus/content.ts
+++ b/src/app/(site)/menus/content.ts
@@ -194,6 +194,18 @@ export const menuIndexPage: PageDoc = {
                 video_media: null,
                 media: {
                   dimensions: {
+                    width: 512,
+                    height: 768,
+                  },
+                  alt: "Guest serving a plate at the buffet with fresh sides and salsa.",
+                  url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/691103be-dfd6-4fcb-4982-c9c9dce41800/public",
+                },
+              },
+              {
+                link: null,
+                video_media: null,
+                media: {
+                  dimensions: {
                     width: 1850,
                     height: 2466,
                   },

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -14,8 +14,8 @@ export default async function Homepage() {
       <JsonLdVideo
         name="The Grand LB — Premier Event Venue in Long Beach, CA"
         description="SoCal's premier 40,000 sq ft event venue. Host weddings, quinceañeras, corporate events, and celebrations across 7 spaces for up to 675 guests. 20 min from LAX."
-        thumbnailUrl="https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/b41a724a-b3ad-40ae-57df-98a1b8ce3400/public"
-        contentUrl="https://cdn.thegrandlb.com/7cff637b-d646-493b-9e81-06266373f84c-homepage-60s-final.mp4"
+        thumbnailUrl="https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/7bc9937a-e01f-4c64-ca20-ad0b7afc2600/public"
+        contentUrl="https://cdn.thegrandlb.com/Homepage%2060s%20v2.mp4"
         uploadDate="2024-06-01T00:00:00+00:00"
         duration="PT1M"
       />

--- a/src/app/(site)/tour/[uid]/content.ts
+++ b/src/app/(site)/tour/[uid]/content.ts
@@ -2558,14 +2558,14 @@ export const tourPages: Record<string, PageDoc> = {
       title: "Grand Ballroom",
       headline: "Grand \nBallroom",
       video_url:
-        "https://cdn.thegrandlb.com/b2bb058f-2bf0-4fec-9a81-db8ca7850d2c-grand-ballroom-30s-final.mp4",
+        "https://cdn.thegrandlb.com/Grand%20Ballroom%2030s.mp4",
       media: {
         dimensions: {
           width: 3840,
           height: 2160,
         },
         alt: "Grand Ballroom with dramatic ceiling, chandeliers, packed dance floor.",
-        url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/c8b247ca-ab6b-4f95-0af4-e412e6ad4c00/public",
+        url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/7403dbe6-914f-4629-f988-4f8743e62f00/public",
       },
       subhead: "Large capacity,\nbigger possibilities.",
       body: "We believe that every occasion is deserving of a personalized touch. Each of our unique spaces is flexible to suit the range of need for any event or gathering.",
@@ -2683,8 +2683,8 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with rounds, stage, and warm chandelier glow.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/48eb9ff1-7ac7-431e-e380-079a64b59a00/public",
+                    alt: "Guests and catering staff at a long buffet line in the Grand Ballroom.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/d13b799e-5120-4d6c-c946-be3e59593d00/public",
                   },
                 },
                 {
@@ -2695,8 +2695,8 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom from rear or balcony: full room, stage, crystal lighting.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/32248fb5-d086-4925-9b48-c43302529100/public",
+                    alt: "Grand Ballroom set with round tables, blush chair sashes, and place settings under ring chandeliers.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/710eb74f-1fce-4e42-89b6-2d41e2643e00/public",
                   },
                 },
                 {
@@ -2720,8 +2720,8 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with dramatic ceiling and central dance floor.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/87f0c8bf-146c-414a-aa10-978ea0890600/public",
+                    alt: "Staff arranging a floral centerpiece on a set table in the Grand Ballroom.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/6b529a71-93b3-4c4b-bf7e-21e5041c0600/public",
                   },
                 },
                 {
@@ -2732,8 +2732,8 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with stage, dance floor, and pink uplighting.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/3562cb12-8916-4107-ba62-834da911cb00/public",
+                    alt: "Place setting with gold chargers and a floral centerpiece in the Grand Ballroom.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/f66e213d-013b-4ac2-2211-52980f90d200/public",
                   },
                 },
                 {
@@ -2744,8 +2744,8 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with dramatic red uplighting and stage.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/50691ccf-e12f-4687-eeae-8bc3f7c66400/public",
+                    alt: "Grand Ballroom set with round tables, peach chair sashes, and a draped floral backdrop.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/3517d7dc-7dfb-4b3b-9158-1326cb29fa00/public",
                   },
                 },
               ],
@@ -3078,7 +3078,7 @@ export const tourPages: Record<string, PageDoc> = {
             data: {
               gallery_items: [
                 {
-                  caption: "Social Setup",
+                  caption: "Social Layout",
                   link: null,
                   video_media: null,
                   media: {
@@ -3086,12 +3086,12 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with pink uplighting and dance floor.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/e2724b59-2b54-48ab-d7fe-7800d2d2fb00/public",
+                    alt: "Grand Ballroom social setup with round tables, blush chair sashes, and pink uplighting.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/ef8c6b56-c2c2-47c6-8e7d-0334a67b2e00/public",
                   },
                 },
                 {
-                  caption: "Fundraiser Setup",
+                  caption: "Head Table & Rounds",
                   link: null,
                   video_media: null,
                   media: {
@@ -3099,12 +3099,12 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with pink uplighting and dance floor.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/bdc5bd25-ad1d-45a3-1242-3fd77afbb800/public",
+                    alt: "Grand Ballroom set with round tables, a long head table, and blush décor.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/e5064f28-331a-45fe-f3af-65f50fb2b400/public",
                   },
                 },
                 {
-                  caption: "Classroom Setup",
+                  caption: "Banquet Tables",
                   link: null,
                   video_media: null,
                   media: {
@@ -3112,12 +3112,12 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with rounds and stage (wide).",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/a99e14e7-1ba6-49c4-1654-ef161e724100/public",
+                    alt: "Grand Ballroom with long banquet tables and rounds under ring chandeliers.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/a808c080-b538-40a8-de54-9ad8645bbc00/public",
                   },
                 },
                 {
-                  caption: "Theater Setup",
+                  caption: "Coffered Ceiling",
                   link: null,
                   video_media: null,
                   media: {
@@ -3125,8 +3125,8 @@ export const tourPages: Record<string, PageDoc> = {
                       width: 3696,
                       height: 2772,
                     },
-                    alt: "Grand Ballroom with pink uplighting and dance floor.",
-                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/fbabdfb9-4baa-4836-0516-44294e16b600/public",
+                    alt: "Grand Ballroom with coffered ceiling, ring chandeliers, and tables below.",
+                    url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/6e4c12c4-0822-4a4a-d16b-ffa9e6546b00/public",
                   },
                 },
               ],
@@ -3168,8 +3168,8 @@ export const tourPages: Record<string, PageDoc> = {
               width: 2772,
               height: 3696,
             },
-            alt: "Grand Ballroom with pink and purple uplighting and stage.",
-            url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/5d755ebb-0900-4db2-3a68-70f3ca2efa00/public",
+            alt: "Coffered ceiling and ring chandeliers in the Grand Ballroom.",
+            url: "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/c9bf38f2-829a-4dd7-c6db-a600327c1500/public",
           },
           asset_position: true,
           items: [

--- a/src/app/(site)/tour/content.ts
+++ b/src/app/(site)/tour/content.ts
@@ -6,14 +6,14 @@ export const tourIndexPage: PageDoc = {
   "uid": "tour",
   "data": {
     "title": "The Grand Tour",
-    "video_url": "https://cdn.thegrandlb.com/2ff5529b-ae2d-4706-9e14-2e9215729acf-tour-index-15s-final.mp4",
+    "video_url": "https://cdn.thegrandlb.com/Tour%20Index%2015s.mp4",
     "media": {
       "dimensions": {
         "width": 3840,
         "height": 2160
       },
       "alt": "Evening exterior of the venue with palms and illuminated facade.",
-      "url": "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/569cb5d0-cd2b-433e-6f65-d237efee8900/public"
+      "url": "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/9b85e6b5-cb44-4d11-c06a-b524ca6cb100/public"
     },
     "icon_media": {
       "dimensions": {
@@ -32,8 +32,8 @@ export const tourIndexPage: PageDoc = {
             "width": 1814,
             "height": 2416
           },
-          "alt": "Grand Ballroom with rounds, stage, and chandeliers.",
-          "url": "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/856df71a-3832-4963-6cc1-1fc9c6115c00/public"
+          "alt": "Grand Ballroom set with round tables, blush chair sashes, and place settings under ring chandeliers.",
+          "url": "https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/710eb74f-1fce-4e42-89b6-2d41e2643e00/public"
         },
         "page": {
           "uid": "grand-ballroom",

--- a/src/app/(site)/tour/page.tsx
+++ b/src/app/(site)/tour/page.tsx
@@ -27,8 +27,8 @@ export default async function Page() {
       <JsonLdVideo
         name="Event Spaces at The Grand LB — Venue Tour"
         description="7 indoor and outdoor event spaces at The Grand Long Beach, CA. From the 675-guest Grand Ballroom to the intimate Board Room. 40,000 sq ft venue 20 min from LAX."
-        thumbnailUrl="https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/569cb5d0-cd2b-433e-6f65-d237efee8900/public"
-        contentUrl="https://cdn.thegrandlb.com/2ff5529b-ae2d-4706-9e14-2e9215729acf-tour-index-15s-final.mp4"
+        thumbnailUrl="https://imagedelivery.net/jq-BfOr8JDGgGxqbx8v5CA/9b85e6b5-cb44-4d11-c06a-b524ca6cb100/public"
+        contentUrl="https://cdn.thegrandlb.com/Tour%20Index%2015s.mp4"
         uploadDate="2024-06-01T00:00:00+00:00"
         duration="PT15S"
       />


### PR DESCRIPTION
## Summary
Refreshes site media with the latest Cloudflare video files and new venue photography across the marketing pages.

- **Videos + posters** updated to the latest Cloudflare files (matching poster images): Homepage, Tour index, Events index, Footer CTA, plus the Grand Ballroom hero.
- **Grand Ballroom page** — new photography for the Setups gallery (with corrected captions: Social Layout / Head Table & Rounds / Banquet Tables / Coffered Ceiling), the features carousel (5 new shots, Private Patio kept), and the FAQ image. Tour-index thumbnail updated to match.
- **Cross-site Grand Ballroom refresh** — replaced the old representative shots on FAQ, Events index, Indian Weddings, Quinces, and Graduation pages with new images (orientation-correct, alt text + dimensions updated).
- **New imagery worked in:**
  - Quinces: sweetheart-table hero + 2 décor cards (Ceremony Backdrop, Reception Details)
  - Weddings: sweetheart-table gallery shot
  - Menus: buffet shot
  - Graduation: outdoor catering shot
  - Milestones: margarita / bar shot

## Test plan
- [ ] Homepage, Tour, Events, FAQ, Menus heroes + footer video load with correct posters
- [ ] /tour/grand-ballroom — setups captions, carousel, FAQ image all correct
- [ ] /events/quinces — sweetheart hero + new décor cards
- [ ] /events/weddings, /events/graduation-parties, /events/milestones — new gallery photos
- [ ] No broken images; mixed portrait/landscape gallery items render acceptably

🤖 Generated with [Claude Code](https://claude.com/claude-code)