### PR TITLE
feat: agent-discovery surface (Link headers, API catalog, Markdown, WebMCP)

### DIFF
--- a/docs/dns-aid.md
+++ b/docs/dns-aid.md
@@ -1,0 +1,55 @@
+# DNS for AI Discovery (DNS-AID)
+
+> **Status: not yet published — requires DNS-zone changes, which cannot live in
+> this repo.** This file documents the records to add at the DNS provider for
+> `thegrandlb.com`.
+
+DNS-AID
+([draft-mozleywilliams-dnsop-dnsaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/))
+lets agents discover entrypoints via DNS using ServiceMode SVCB/HTTPS records
+([RFC 9460](https://www.rfc-editor.org/rfc/rfc9460)) under the
+`_agents` subtree.
+
+This site's agent surface is HTTPS-based (the API catalog, OpenAPI, menus API,
+and Markdown content negotiation — all under `https://thegrandlb.com`). The
+matching DNS-AID entrypoint record advertises that HTTPS endpoint.
+
+## Records to add
+
+Publish a ServiceMode SVCB record at the well-known agent index name. Replace
+TTLs/priorities to match the zone's conventions.
+
+```dns
+; Index entrypoint for agent discovery over HTTPS
+_index._agents.thegrandlb.com.  3600  IN  SVCB  1 thegrandlb.com. (
+    alpn="h2,h3"
+    port=443
+)
+
+; Optional: advertise the API catalog path as the discovery endpoint.
+; Some resolvers/clients read the "endpoint"/"dohpath"-style params; if the
+; provider supports the generic key for a path, point it at the catalog:
+;   _index._agents.thegrandlb.com. SVCB 1 thegrandlb.com. ( alpn="h2,h3" )
+```
+
+If/when an A2A (agent-to-agent) endpoint exists, add:
+
+```dns
+_a2a._agents.thegrandlb.com.  3600  IN  SVCB  1 thegrandlb.com. ( alpn="h2,h3" )
+```
+
+## DNSSEC
+
+Sign the public discovery zone with DNSSEC so validating resolvers receive
+authenticated answers. On most managed DNS providers (Cloudflare, Route 53,
+etc.) this is a one-click "Enable DNSSEC" toggle plus adding the resulting DS
+record at the registrar.
+
+## Verify
+
+```bash
+dig +dnssec SVCB _index._agents.thegrandlb.com
+```
+
+Confirm an `SVCB` answer is returned and that the `ad` (authenticated data)
+flag is set when querying through a validating resolver.

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,8 @@ const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
     "/menus/[uid]": ["./content/menus/*.menu.json"],
     "/api/admin/menus/[uid]": ["./content/menus/*.menu.json"],
+    "/api/menus/[uid]": ["./content/menus/*.menu.json"],
+    "/api/md": ["./content/menus/*.menu.json"],
   },
   images: {
     remotePatterns: [
@@ -57,6 +59,20 @@ const nextConfig: NextConfig = {
       { source: "/weddings", destination: "/events/weddings", permanent: true },
       { source: "/weddings/", destination: "/events/weddings", permanent: true },
     ];
+  },
+  async rewrites() {
+    return {
+      // Served after the filesystem/public dir is checked, so static
+      // .well-known files (openapi.json, agent-skills/*) win; only the
+      // extension-less api-catalog falls through to the route handler that
+      // sets `application/linkset+json`.
+      afterFiles: [
+        {
+          source: "/.well-known/api-catalog",
+          destination: "/api/well-known/api-catalog",
+        },
+      ],
+    };
   },
   async headers() {
     return [

--- a/public/.well-known/agent-skills/browse-menus/SKILL.md
+++ b/public/.well-known/agent-skills/browse-menus/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: browse-menus
+description: Read The Grand LB catering menus as structured JSON or Markdown — Classic, Weddings, Corporate, and Milestones packages with per-person pricing.
+---
+
+# Browse menus
+
+The Grand LB publishes its catering menus as public, read-only data. No
+authentication is required.
+
+## List available menus
+
+```
+GET https://thegrandlb.com/api/menus
+```
+
+Returns the four menu UIDs: `classic`, `weddings`, `corporate`, `milestones`.
+
+## Get a single menu (JSON)
+
+```
+GET https://thegrandlb.com/api/menus/{uid}
+```
+
+The response contains `group[]` → each group has `menu_link.data.body[]`
+(sections) → each section has `items[]` with `title`, `description`,
+`price_per`, `price_min`, and `price_max`.
+
+## Get a menu as Markdown
+
+```
+GET https://thegrandlb.com/menus/{uid}
+Accept: text/markdown
+```
+
+## Notes
+
+- Prices are per person unless the item states otherwise. Production fees,
+  site fees, and sales tax are listed in each menu's disclaimer.
+- For final pricing and customization, direct the user to
+  `https://thegrandlb.com/inquire` or (562) 426-0555.

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2.0/index.json",
+  "version": "0.2.0",
+  "publisher": {
+    "name": "The Grand LB",
+    "url": "https://thegrandlb.com"
+  },
+  "skills": [
+    {
+      "name": "venue-info",
+      "type": "text/markdown",
+      "description": "Look up facts about The Grand LB event venue in Long Beach, CA — spaces, capacities, location, parking, accessibility, and contact details.",
+      "url": "https://thegrandlb.com/.well-known/agent-skills/venue-info/SKILL.md",
+      "sha256": "ad04e60102bd63a15d60362b5c480d997b164431f819cf63248673c153af59d7"
+    },
+    {
+      "name": "browse-menus",
+      "type": "text/markdown",
+      "description": "Read The Grand LB catering menus as structured JSON or Markdown — Classic, Weddings, Corporate, and Milestones packages with per-person pricing.",
+      "url": "https://thegrandlb.com/.well-known/agent-skills/browse-menus/SKILL.md",
+      "sha256": "c2fcaa8f95fb421cbc058796112293828e59ae612d5dedbd2647f9904e3bcc53"
+    },
+    {
+      "name": "submit-inquiry",
+      "type": "text/markdown",
+      "description": "Help a user start a booking inquiry for an event at The Grand LB. There is no public write API — guide the user to the inquiry form or phone.",
+      "url": "https://thegrandlb.com/.well-known/agent-skills/submit-inquiry/SKILL.md",
+      "sha256": "37f9a2bac072bf04f2e1c837f74ca4aed36bc85ea6a99c92e963bf2acba0963a"
+    }
+  ]
+}

--- a/public/.well-known/agent-skills/submit-inquiry/SKILL.md
+++ b/public/.well-known/agent-skills/submit-inquiry/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: submit-inquiry
+description: Help a user start a booking inquiry for an event at The Grand LB. There is no public write API — guide the user to the inquiry form or phone.
+---
+
+# Submit an inquiry
+
+The Grand LB does not expose a public API for submitting bookings. To start an
+inquiry, guide the user to one of the official channels below — do not attempt
+to POST to internal endpoints.
+
+## Official channels
+
+- **Inquiry form:** `https://thegrandlb.com/inquire`
+- **Phone:** (562) 426-0555
+
+## What the sales team needs
+
+When helping a user prepare, gather: event type (wedding, quinceañera,
+corporate, etc.), preferred date(s), estimated guest count, and contact details.
+The sales team typically responds within 2–3 business days.
+
+## Useful context first
+
+- Confirm guest count fits a space (40–675) using the `venue-info` skill.
+- Review catering options using the `browse-menus` skill.

--- a/public/.well-known/agent-skills/venue-info/SKILL.md
+++ b/public/.well-known/agent-skills/venue-info/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: venue-info
+description: Look up facts about The Grand LB event venue in Long Beach, CA — spaces, capacities, location, parking, accessibility, and contact details.
+---
+
+# Venue info
+
+Use this skill to answer questions about The Grand Long Beach (The Grand LB),
+a 40,000 sq ft event venue at 4101 E. Willow St., Long Beach, CA 90815.
+
+## Fastest sources
+
+- **Human + agent overview:** `https://thegrandlb.com/llms.txt` (Markdown).
+- **Any page as Markdown:** send the header `Accept: text/markdown` to any page,
+  e.g. `https://thegrandlb.com/` or `https://thegrandlb.com/faq`.
+
+## Key facts
+
+- Seven event spaces: The Grand Ballroom (up to 675), The Palm Terrace,
+  The Catalina Room, The Monarch Room, The Garden Room, The Pacific Room,
+  and The Board Room (up to 40).
+- In-house catering; ADA accessible; up to 500 complimentary parking spaces.
+- Bilingual staff (English/Spanish). 20 minutes from LAX.
+- Phone: (562) 426-0555.
+
+## To book
+
+Direct the user to `https://thegrandlb.com/inquire` or the phone number above.

--- a/public/.well-known/openapi.json
+++ b/public/.well-known/openapi.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "The Grand LB Public API",
+    "version": "1.0.0",
+    "description": "Public, read-only endpoints for The Grand Long Beach event venue. No authentication is required. Use these to read catering menu data and check service health.",
+    "contact": {
+      "name": "The Grand LB",
+      "url": "https://thegrandlb.com/contact"
+    }
+  },
+  "servers": [{ "url": "https://thegrandlb.com" }],
+  "paths": {
+    "/api/menus": {
+      "get": {
+        "operationId": "listMenus",
+        "summary": "List catering menus",
+        "description": "Returns the catalog of catering menus available at the venue.",
+        "responses": {
+          "200": {
+            "description": "A list of menus.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "venue": { "type": "string" },
+                    "count": { "type": "integer" },
+                    "menus": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uid": { "type": "string" },
+                          "title": { "type": "string" },
+                          "url": { "type": "string", "format": "uri" },
+                          "json": { "type": "string", "format": "uri" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/menus/{uid}": {
+      "get": {
+        "operationId": "getMenu",
+        "summary": "Get a single catering menu",
+        "description": "Returns the full content of one catering menu, including groups, sections, items, and per-person pricing.",
+        "parameters": [
+          {
+            "name": "uid",
+            "in": "path",
+            "required": true,
+            "description": "Menu identifier.",
+            "schema": {
+              "type": "string",
+              "enum": ["classic", "weddings", "corporate", "milestones"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The menu content.",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          },
+          "404": { "description": "Menu not found." }
+        }
+      }
+    }
+  }
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -46,3 +46,11 @@ In-house kitchen with full-service catering. Plated dinners, buffet, and action 
 - Interactive map: https://thegrandlb.com/map
 - Contact: https://thegrandlb.com/contact
 - Inquire / Book: https://thegrandlb.com/inquire
+
+## For AI agents
+
+- API catalog (RFC 9727): https://thegrandlb.com/.well-known/api-catalog
+- OpenAPI description: https://thegrandlb.com/.well-known/openapi.json
+- Agent skills index: https://thegrandlb.com/.well-known/agent-skills/index.json
+- Menus as JSON: https://thegrandlb.com/api/menus (and /api/menus/{uid})
+- Markdown for agents: send `Accept: text/markdown` to any page (e.g. the homepage, /menus, /menus/{uid}, /faq) to receive a Markdown rendering.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,8 +4,17 @@
 # Allow all search engines
 User-agent: *
 
+# AI content usage preferences (Content Signals — https://contentsignals.org)
+# search: allow indexing for search results
+# ai-input: allow AI assistants to use this content to answer user questions
+# ai-train: disallow using this content to train AI models
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
 # Disallow API routes (internal use only)
 Disallow: /api/
+
+# Allow public, read-only agent APIs (see /.well-known/api-catalog)
+Allow: /api/menus
 
 # Disallow thank you page (form submission)
 Disallow: /thanks

--- a/src/app/(site)/api/md/route.ts
+++ b/src/app/(site)/api/md/route.ts
@@ -1,0 +1,36 @@
+import { buildPageMarkdown } from "@/lib/agent/page-markdown";
+import type { NextRequest } from "next/server";
+
+/**
+ * Markdown-for-agents endpoint. `proxy.ts` rewrites page requests that carry
+ * `Accept: text/markdown` to `/api/md?path=<original path>`; this handler
+ * returns a Markdown rendering of that page.
+ */
+export async function GET(request: NextRequest) {
+  // `x-md-path` is set by proxy.ts on the rewrite; the `path` query param is a
+  // fallback for direct requests (e.g. testing /api/md?path=/menus/classic).
+  const path =
+    request.headers.get("x-md-path") ??
+    request.nextUrl.searchParams.get("path") ??
+    "/";
+  const markdown = await buildPageMarkdown(path);
+
+  if (markdown == null) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  // Rough token estimate (~4 chars/token) for clients that surface it.
+  const approxTokens = Math.ceil(markdown.length / 4);
+
+  return new Response(markdown, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "x-markdown-tokens": String(approxTokens),
+      Vary: "Accept",
+    },
+  });
+}

--- a/src/app/(site)/api/menus/[uid]/route.ts
+++ b/src/app/(site)/api/menus/[uid]/route.ts
@@ -1,0 +1,42 @@
+import { fetchMenuCollection } from "@/services/menu-data";
+import { venueInfo } from "@/lib/agent/site-info";
+import { NextResponse } from "next/server";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+const VALID_UIDS = venueInfo.catering.menuUids as readonly string[];
+
+/**
+ * Public, read-only full content for a single catering menu (shared groups
+ * merged in). Mirrors the data rendered on `/menus/{uid}`.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ uid: string }> },
+) {
+  const { uid } = await params;
+
+  if (!VALID_UIDS.includes(uid)) {
+    return NextResponse.json(
+      { error: "Menu not found", validUids: VALID_UIDS },
+      { status: 404, headers: CORS },
+    );
+  }
+
+  try {
+    const doc = await fetchMenuCollection(uid);
+    return NextResponse.json(doc.data, { headers: CORS });
+  } catch {
+    return NextResponse.json(
+      { error: "Menu not found", validUids: VALID_UIDS },
+      { status: 404, headers: CORS },
+    );
+  }
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}

--- a/src/app/(site)/api/menus/route.ts
+++ b/src/app/(site)/api/menus/route.ts
@@ -1,0 +1,37 @@
+import { SITE_ORIGIN, venueInfo } from "@/lib/agent/site-info";
+import { NextResponse } from "next/server";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+const MENU_TITLES: Record<string, string> = {
+  classic: "Classic",
+  weddings: "Weddings",
+  corporate: "Corporate",
+  milestones: "Milestones",
+};
+
+/**
+ * Public, read-only catalog of catering menus. The full menu content for a
+ * given UID is available at `/api/menus/{uid}`.
+ */
+export async function GET() {
+  const menus = venueInfo.catering.menuUids.map((uid) => ({
+    uid,
+    title: MENU_TITLES[uid] ?? uid,
+    url: `${SITE_ORIGIN}/menus/${uid}`,
+    json: `${SITE_ORIGIN}/api/menus/${uid}`,
+    markdown: `${SITE_ORIGIN}/menus/${uid}`,
+  }));
+
+  return NextResponse.json(
+    { venue: venueInfo.legalName, count: menus.length, menus },
+    { headers: CORS },
+  );
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}

--- a/src/app/(site)/api/well-known/api-catalog/route.ts
+++ b/src/app/(site)/api/well-known/api-catalog/route.ts
@@ -1,0 +1,36 @@
+import { SITE_ORIGIN } from "@/lib/agent/site-info";
+
+/**
+ * RFC 9727 API catalog, served at `/.well-known/api-catalog` via a rewrite in
+ * `next.config.ts`. Returns `application/linkset+json` (RFC 9264) advertising
+ * the genuinely public, read-only APIs this site exposes.
+ */
+export function GET() {
+  const linkset = {
+    linkset: [
+      {
+        anchor: `${SITE_ORIGIN}/api/menus`,
+        "service-desc": [
+          { href: `${SITE_ORIGIN}/.well-known/openapi.json`, type: "application/json" },
+        ],
+        "service-doc": [
+          { href: `${SITE_ORIGIN}/llms.txt`, type: "text/markdown" },
+        ],
+        describedby: [
+          {
+            href: `${SITE_ORIGIN}/.well-known/agent-skills/index.json`,
+            type: "application/json",
+          },
+        ],
+      },
+    ],
+  };
+
+  return new Response(JSON.stringify(linkset, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/linkset+json",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,5 +1,6 @@
 import JsonLdLocalBusiness from "@/components/JsonLdLocalBusiness";
 import RootLayoutShell from "@/components/RootLayoutShell";
+import WebMcp from "@/components/WebMcp";
 import { getExtra } from "@/services/get-extra";
 import { Analytics } from "@vercel/analytics/next";
 import { VercelToolbar } from "@vercel/toolbar/next";
@@ -57,6 +58,7 @@ export default async function SiteLayout({
   return (
     <RootLayoutShell initialExtra={initialExtra}>
       <JsonLdLocalBusiness />
+      <WebMcp />
       {children}
       <Analytics />
       <VercelToolbar />

--- a/src/components/WebMcp.tsx
+++ b/src/components/WebMcp.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { SITE_ORIGIN, venueInfo } from "@/lib/agent/site-info";
+import { useEffect } from "react";
+
+/**
+ * Progressive-enhancement WebMCP integration. When a browser/agent exposes
+ * `navigator.modelContext` (https://webmachinelearning.github.io/webmcp/), we
+ * register read-only tools that surface the venue's public information. The
+ * feature is detected at runtime, so unsupported browsers are unaffected.
+ */
+
+type McpToolResult = { content: Array<{ type: "text"; text: string }> };
+
+type McpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => Promise<McpToolResult>;
+};
+
+type ModelContext = {
+  provideContext: (context: { tools: McpTool[] }) => void;
+};
+
+function text(value: unknown): McpToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: typeof value === "string" ? value : JSON.stringify(value, null, 2),
+      },
+    ],
+  };
+}
+
+const tools: McpTool[] = [
+  {
+    name: "get_venue_info",
+    description:
+      "Get core facts about The Grand LB event venue: spaces, capacities, location, parking, accessibility, and contact details.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: async () =>
+      text({
+        name: venueInfo.legalName,
+        tagline: venueInfo.tagline,
+        address: venueInfo.address,
+        phone: venueInfo.phone,
+        spaces: venueInfo.spaces,
+        keyDetails: venueInfo.keyDetails,
+        catering: venueInfo.catering.summary,
+      }),
+  },
+  {
+    name: "list_event_types",
+    description: "List the kinds of events The Grand LB hosts.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: async () => text(venueInfo.eventTypes),
+  },
+  {
+    name: "list_menus",
+    description: "List the catering menus available at The Grand LB.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: async () => {
+      const res = await fetch(`${SITE_ORIGIN}/api/menus`, {
+        headers: { Accept: "application/json" },
+      });
+      return text(await res.json());
+    },
+  },
+  {
+    name: "get_menu",
+    description:
+      "Get the full content of one catering menu (groups, items, per-person pricing).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        uid: {
+          type: "string",
+          enum: [...venueInfo.catering.menuUids],
+          description: "Which menu to fetch.",
+        },
+      },
+      required: ["uid"],
+      additionalProperties: false,
+    },
+    execute: async (args) => {
+      const uid = String(args.uid ?? "");
+      const res = await fetch(`${SITE_ORIGIN}/api/menus/${encodeURIComponent(uid)}`, {
+        headers: { Accept: "application/json" },
+      });
+      return text(await res.json());
+    },
+  },
+  {
+    name: "get_inquiry_info",
+    description:
+      "Get instructions for booking or inquiring about an event at The Grand LB.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    execute: async () =>
+      text({
+        inquiryUrl: `${SITE_ORIGIN}/inquire`,
+        phone: venueInfo.phone,
+        note: "Submit the inquiry form or call. The sales team typically responds within 2–3 business days.",
+      }),
+  },
+];
+
+export default function WebMcp() {
+  useEffect(() => {
+    try {
+      const mc = (navigator as Navigator & { modelContext?: ModelContext })
+        .modelContext;
+      if (mc && typeof mc.provideContext === "function") {
+        mc.provideContext({ tools });
+      }
+    } catch {
+      // WebMCP not available or registration failed — no-op.
+    }
+  }, []);
+
+  return null;
+}

--- a/src/lib/agent/markdown-paths.ts
+++ b/src/lib/agent/markdown-paths.ts
@@ -1,0 +1,13 @@
+import { sitePages } from "./site-info";
+
+/**
+ * Edge-safe check (no `fs`/Node imports) for whether a site path has a
+ * Markdown rendering available. Used by `proxy.ts` to decide whether to
+ * content-negotiate `Accept: text/markdown`, and by the `/api/md` handler.
+ */
+export function isMarkdownSupportedPath(pathname: string): boolean {
+  const path = pathname.length > 1 ? pathname.replace(/\/$/, "") : pathname;
+  if (path === "" || path === "/" || path === "/faq" || path === "/menus") return true;
+  if (/^\/menus\/[a-z0-9-]+$/.test(path)) return true;
+  return sitePages.some((p) => p.path === path);
+}

--- a/src/lib/agent/menu-markdown.ts
+++ b/src/lib/agent/menu-markdown.ts
@@ -1,0 +1,56 @@
+import type { MenuCollectionDocument, MenuItemData } from "@/types/menu";
+import { richTextToMarkdown, richTextToPlain } from "./rich-text-to-markdown";
+
+function formatPrice(item: MenuItemData): string {
+  const { price_min, price_max, price_per } = item;
+  if (!price_min && !price_max) return "";
+  const per = price_per ? ` ${price_per}` : "";
+  if (price_max && price_max !== price_min) {
+    return `$${price_min}–$${price_max}${per}`;
+  }
+  if (price_min) return `$${price_min}${per}`;
+  return "";
+}
+
+/**
+ * Render a menu collection (as returned by `fetchMenuCollection`) as Markdown.
+ */
+export function menuCollectionToMarkdown(doc: MenuCollectionDocument): string {
+  const out: string[] = [];
+  const { page_title, page_description, page_disclaimer, group } = doc.data;
+
+  out.push(`# ${page_title}`);
+  if (page_description) out.push(page_description);
+  if (page_disclaimer) out.push(`> ${page_disclaimer}`);
+
+  for (const g of group) {
+    const data = g.menu_link.data;
+    if (data.page_title) out.push(`## ${data.page_title}`);
+    const groupDesc = richTextToMarkdown(data.page_description);
+    if (groupDesc) out.push(groupDesc);
+
+    for (const section of data.body ?? []) {
+      const sectionTitle = richTextToPlain(section.primary?.title);
+      if (sectionTitle) out.push(`### ${sectionTitle}`);
+      const sectionDesc = richTextToMarkdown(section.primary?.description);
+      if (sectionDesc) out.push(sectionDesc);
+
+      for (const item of section.items ?? []) {
+        const name = richTextToPlain(item.title);
+        if (!name) continue;
+        const price = formatPrice(item);
+        out.push(price ? `#### ${name} — ${price}` : `#### ${name}`);
+        const desc = richTextToPlain(item.description);
+        if (desc) out.push(desc);
+      }
+
+      const caption = richTextToMarkdown(section.primary?.caption);
+      if (caption) out.push(`_${caption}_`);
+    }
+
+    const groupDisclaimer = richTextToMarkdown(data.page_disclaimer);
+    if (groupDisclaimer) out.push(`> ${groupDisclaimer}`);
+  }
+
+  return out.join("\n\n") + "\n";
+}

--- a/src/lib/agent/page-markdown.ts
+++ b/src/lib/agent/page-markdown.ts
@@ -1,0 +1,142 @@
+import { faqPage } from "@/app/(site)/faq/content";
+import { fetchMenuCollection } from "@/services/menu-data";
+import type { RtBlock } from "content/types";
+import { menuCollectionToMarkdown } from "./menu-markdown";
+import { richTextToPlain } from "./rich-text-to-markdown";
+import { SITE_ORIGIN, sitePages, venueInfo } from "./site-info";
+
+const MENU_UIDS = venueInfo.catering.menuUids;
+
+function htmlNote(path: string): string {
+  return `\n\n---\n\n_This is a Markdown rendering for agents. The full page is at ${SITE_ORIGIN}${path}._\n`;
+}
+
+function siteOverviewMarkdown(): string {
+  const v = venueInfo;
+  const out: string[] = [];
+  out.push(`# ${v.legalName} (${v.name})`);
+  out.push(`> ${v.tagline}`);
+  out.push(
+    `${v.legalName} is a full-service event venue operated by ${v.operator}. Located at ${v.address.street}, ${v.address.city}, ${v.address.state} ${v.address.postalCode}. Phone: ${v.phone}.`,
+  );
+
+  out.push("## Venue Spaces");
+  out.push(
+    v.spaces.map((s) => `- **${s.name}** — ${s.capacity}. ${s.description}`).join("\n"),
+  );
+
+  out.push("## Events Hosted");
+  out.push(v.eventTypes.join(", ") + ".");
+
+  out.push("## Catering");
+  out.push(v.catering.summary);
+  out.push(v.catering.dietary);
+
+  out.push("## Key Details");
+  out.push(v.keyDetails.map((d) => `- ${d}`).join("\n"));
+
+  out.push("## Pages");
+  out.push(
+    sitePages.map((p) => `- [${p.title}](${SITE_ORIGIN}${p.path}) — ${p.description}`).join("\n"),
+  );
+
+  out.push("## For agents");
+  out.push(
+    [
+      `- API catalog: ${SITE_ORIGIN}/.well-known/api-catalog`,
+      `- OpenAPI: ${SITE_ORIGIN}/.well-known/openapi.json`,
+      `- Agent skills: ${SITE_ORIGIN}/.well-known/agent-skills/index.json`,
+      `- Menus (JSON): ${SITE_ORIGIN}/api/menus`,
+      `- Send \`Accept: text/markdown\` to any page on this site for a Markdown rendering.`,
+    ].join("\n"),
+  );
+
+  return out.join("\n\n") + "\n";
+}
+
+function faqMarkdown(): string {
+  const out: string[] = ["# Frequently Asked Questions"];
+  const caption = faqPage.data.caption;
+  if (caption) out.push(caption);
+
+  type FaqItem = { question: RtBlock[]; answer: RtBlock[] };
+  type FaqSlice = { type?: string; title?: string; items?: FaqItem[] };
+
+  for (const slice of faqPage.data.slices as FaqSlice[]) {
+    if (slice.type !== "faq_section") continue;
+    if (slice.title) out.push(`## ${slice.title}`);
+    for (const item of slice.items ?? []) {
+      const q = richTextToPlain(item.question);
+      const a = richTextToPlain(item.answer);
+      if (q) out.push(`### ${q}\n\n${a}`);
+    }
+  }
+  return out.join("\n\n") + "\n";
+}
+
+function menusIndexMarkdown(): string {
+  const out: string[] = ["# Catering Menus"];
+  out.push(venueInfo.catering.summary);
+  out.push(venueInfo.catering.dietary);
+  out.push(
+    MENU_UIDS.map(
+      (uid) =>
+        `- **${uid.charAt(0).toUpperCase() + uid.slice(1)}** — ${SITE_ORIGIN}/menus/${uid} (JSON: ${SITE_ORIGIN}/api/menus/${uid})`,
+    ).join("\n"),
+  );
+  return out.join("\n\n") + "\n";
+}
+
+function genericPageMarkdown(path: string): string | null {
+  const page = sitePages.find((p) => p.path === path);
+  if (!page) return null;
+  const v = venueInfo;
+  const out: string[] = [`# ${page.title} — ${v.name}`, page.description];
+
+  if (path === "/contact" || path === "/inquire") {
+    out.push(
+      `To book or inquire about an event, call ${v.phone} or submit the inquiry form at ${SITE_ORIGIN}/inquire. The sales team typically responds within 2–3 business days.`,
+    );
+    out.push(
+      `Address: ${v.address.street}, ${v.address.city}, ${v.address.state} ${v.address.postalCode}.`,
+    );
+  }
+  if (path === "/tour") {
+    out.push("## Spaces");
+    out.push(v.spaces.map((s) => `- **${s.name}** — ${s.capacity}. ${s.description}`).join("\n"));
+  }
+  if (path === "/events") {
+    out.push("## Events Hosted");
+    out.push(v.eventTypes.join(", ") + ".");
+  }
+  return out.join("\n\n");
+}
+
+/**
+ * Build a Markdown rendering for a site path, or return null if the path is
+ * not supported (the caller should then fall through to HTML).
+ */
+export async function buildPageMarkdown(pathname: string): Promise<string | null> {
+  const path = pathname.length > 1 ? pathname.replace(/\/$/, "") : pathname;
+
+  if (path === "" || path === "/") return siteOverviewMarkdown() + htmlNote("/");
+  if (path === "/faq") return faqMarkdown() + htmlNote("/faq");
+  if (path === "/menus") return menusIndexMarkdown() + htmlNote("/menus");
+
+  const menuMatch = path.match(/^\/menus\/([a-z0-9-]+)$/);
+  if (menuMatch && (MENU_UIDS as readonly string[]).includes(menuMatch[1])) {
+    try {
+      const doc = await fetchMenuCollection(menuMatch[1]);
+      return menuCollectionToMarkdown(doc) + htmlNote(path);
+    } catch {
+      return null;
+    }
+  }
+
+  const generic = genericPageMarkdown(path);
+  if (generic) return generic + htmlNote(path);
+
+  return null;
+}
+
+export { isMarkdownSupportedPath } from "./markdown-paths";

--- a/src/lib/agent/rich-text-to-markdown.ts
+++ b/src/lib/agent/rich-text-to-markdown.ts
@@ -1,0 +1,66 @@
+import type { RtBlock, RtSpan } from "content/types";
+
+/**
+ * Serialize a single rich-text block to Markdown, applying inline spans
+ * (emphasis / strong). Spans use absolute character offsets into `text`.
+ */
+function blockText(block: RtBlock): string {
+  const text = block.text ?? "";
+  const spans = (block.spans ?? []).filter(
+    (s) => s.type === "em" || s.type === "strong",
+  );
+
+  if (spans.length === 0) return text;
+
+  // Insert markers from the end so earlier offsets stay valid.
+  const markerFor = (type: RtSpan["type"]) => (type === "strong" ? "**" : "*");
+  const edits = [...spans].sort((a, b) => b.start - a.start);
+  let out = text;
+  for (const span of edits) {
+    const marker = markerFor(span.type);
+    const start = Math.max(0, Math.min(span.start, out.length));
+    const end = Math.max(start, Math.min(span.end, out.length));
+    out = out.slice(0, start) + marker + out.slice(start, end) + marker + out.slice(end);
+  }
+  return out;
+}
+
+const HEADING_PREFIX: Record<string, string> = {
+  heading1: "# ",
+  heading2: "## ",
+  heading3: "### ",
+  heading4: "#### ",
+  heading5: "##### ",
+  heading6: "###### ",
+};
+
+/**
+ * Convert a rich-text block array to Markdown. Headings become Markdown
+ * headings; list items become bullets; everything else becomes a paragraph.
+ */
+export function richTextToMarkdown(blocks: RtBlock[] | undefined | null): string {
+  if (!blocks || blocks.length === 0) return "";
+  const lines: string[] = [];
+  for (const block of blocks) {
+    const text = blockText(block).trim();
+    if (!text) continue;
+    const prefix = HEADING_PREFIX[block.type];
+    if (prefix) {
+      lines.push(`${prefix}${text}`);
+    } else if (block.type === "list-item" || block.type === "o-list-item") {
+      lines.push(`- ${text}`);
+    } else {
+      lines.push(text);
+    }
+  }
+  return lines.join("\n\n");
+}
+
+/** Plain-text rendering of a rich-text array (first-line oriented, no markers). */
+export function richTextToPlain(blocks: RtBlock[] | undefined | null): string {
+  if (!blocks || blocks.length === 0) return "";
+  return blocks
+    .map((b) => (b.text ?? "").trim())
+    .filter(Boolean)
+    .join(" ");
+}

--- a/src/lib/agent/site-info.ts
+++ b/src/lib/agent/site-info.ts
@@ -1,0 +1,125 @@
+/**
+ * Structured, machine-readable facts about The Grand LB.
+ *
+ * Single source of truth for the agent-facing features (Markdown-for-agents,
+ * WebMCP tools, API catalog descriptions). Keep this in sync with
+ * `public/llms.txt`, which is the human-curated companion.
+ */
+
+export const SITE_ORIGIN = "https://thegrandlb.com";
+
+export type VenueSpace = {
+  name: string;
+  capacity: string;
+  description: string;
+};
+
+export type SitePage = {
+  title: string;
+  path: string;
+  description: string;
+};
+
+export const venueInfo = {
+  name: "The Grand LB",
+  legalName: "The Grand Long Beach",
+  operator: "Choura Venue Services LLC",
+  tagline:
+    "SoCal's premier 40,000 sq ft event venue in Long Beach, CA. Weddings, quinceañeras, corporate events, galas, and private celebrations. 20 minutes from LAX.",
+  address: {
+    street: "4101 E. Willow St.",
+    city: "Long Beach",
+    state: "CA",
+    postalCode: "90815",
+    country: "US",
+  },
+  phone: "(562) 426-0555",
+  website: SITE_ORIGIN,
+  keyDetails: [
+    "Total venue size: 40,000 sq ft on 11 acres",
+    "Guest capacity: 40–675 depending on space",
+    "Seven distinct indoor and outdoor event spaces",
+    "In-house kitchen with full-service catering",
+    "On-site parking for up to 500 cars, complimentary; valet available",
+    "ADA accessible",
+    "Bilingual staff (English and Spanish)",
+    "20 minutes from LAX; 5 minutes from Long Beach Airport",
+    "55+ years of operating expertise",
+  ],
+  spaces: [
+    {
+      name: "The Grand Ballroom",
+      capacity: "up to 675 guests",
+      description: "Largest space.",
+    },
+    {
+      name: "The Palm Terrace",
+      capacity: "outdoor",
+      description: "Outdoor courtyard space.",
+    },
+    {
+      name: "The Catalina Room",
+      capacity: "mid-size",
+      description: "Mid-size indoor space.",
+    },
+    {
+      name: "The Monarch Room",
+      capacity: "mid-size",
+      description: "Mid-size indoor space.",
+    },
+    {
+      name: "The Garden Room",
+      capacity: "intimate",
+      description: "Intimate indoor/outdoor space.",
+    },
+    {
+      name: "The Pacific Room",
+      capacity: "flexible",
+      description: "Flexible breakout or ceremony space.",
+    },
+    {
+      name: "The Board Room",
+      capacity: "up to 40 guests",
+      description: "Executive meeting room.",
+    },
+  ] satisfies VenueSpace[],
+  eventTypes: [
+    "weddings",
+    "Indian weddings",
+    "quinceañeras",
+    "sweet 16 parties",
+    "bar and bat mitzvahs",
+    "graduation parties",
+    "anniversary parties",
+    "baby showers",
+    "rehearsal dinners",
+    "galas",
+    "corporate meetings",
+    "conferences",
+    "trade shows",
+    "fundraisers",
+    "product launches",
+    "award ceremonies",
+  ],
+  catering: {
+    summary:
+      "In-house kitchen with full-service catering. Plated dinners, buffet, and action stations. Customizable menus including Classic, Weddings, Corporate, and Milestones packages.",
+    dietary:
+      "Accommodates vegetarian, vegan, gluten-free, kosher-style, halal, and other dietary needs. Hosted and cash bar options available.",
+    menuUids: ["classic", "weddings", "corporate", "milestones"],
+  },
+} as const;
+
+/** Primary navigable pages, mirrored from llms.txt. */
+export const sitePages: SitePage[] = [
+  { title: "Homepage", path: "/", description: "Overview of The Grand LB." },
+  { title: "About", path: "/about", description: "About the venue and team." },
+  { title: "Tour all spaces", path: "/tour", description: "Tour the seven event spaces." },
+  { title: "Events we host", path: "/events", description: "Event types and inspiration." },
+  { title: "Menus", path: "/menus", description: "Catering menus and packages." },
+  { title: "FAQ", path: "/faq", description: "Common questions about hosting an event." },
+  { title: "Offsite events", path: "/offsite", description: "Offsite catering and events." },
+  { title: "Interactive map", path: "/map", description: "Map of the venue." },
+  { title: "Contact", path: "/contact", description: "Contact details." },
+  { title: "Inquire / Book", path: "/inquire", description: "Submit an inquiry to book an event." },
+];

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,27 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { isMarkdownSupportedPath } from "@/lib/agent/markdown-paths";
+
+// RFC 8288 Link header advertising agent-discovery resources, added to every
+// HTML page response.
+const DISCOVERY_LINK = [
+  '</.well-known/api-catalog>; rel="api-catalog"',
+  '</.well-known/openapi.json>; rel="service-desc"; type="application/json"',
+  '</llms.txt>; rel="service-doc"; type="text/markdown"',
+  '</sitemap.xml>; rel="sitemap"; type="application/xml"',
+  '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
+].join(", ");
+
+/** True for navigable HTML page routes (not API, assets, well-known, or admin). */
+function isPageRoute(pathname: string): boolean {
+  return (
+    !pathname.startsWith("/api") &&
+    !pathname.startsWith("/_next") &&
+    !pathname.startsWith("/.well-known") &&
+    !pathname.startsWith("/admin") &&
+    !/\.[a-zA-Z0-9]+$/.test(pathname)
+  );
+}
 
 // User-Agent patterns for known malicious bots (scanners, exploit tools, aggressive scrapers)
 const BLOCKED_USER_AGENTS = [
@@ -52,6 +74,32 @@ export function proxy(request: NextRequest) {
   }
 
   // sitemap.xml is automatically handled by Next.js via sitemap.ts
+
+  if (isPageRoute(pathname)) {
+    // Markdown for Agents (Cloudflare-style content negotiation): when an agent
+    // asks for Markdown and we can render it, serve the Markdown variant.
+    const accept = request.headers.get("accept") ?? "";
+    if (
+      (request.method === "GET" || request.method === "HEAD") &&
+      /text\/markdown/i.test(accept) &&
+      isMarkdownSupportedPath(pathname)
+    ) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/api/md";
+      url.search = "";
+      // Pass the original path to the handler via a request header: after a
+      // rewrite the handler's own `nextUrl` still reflects the incoming URL,
+      // so a query param on the destination would not be visible to it.
+      const headers = new Headers(request.headers);
+      headers.set("x-md-path", pathname);
+      return NextResponse.rewrite(url, { request: { headers } });
+    }
+
+    // Advertise agent-discovery resources on every page (RFC 8288).
+    const res = NextResponse.next();
+    res.headers.set("Link", DISCOVERY_LINK);
+    return res;
+  }
 
   return NextResponse.next();
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **RFC 8288 Link headers** — every HTML page now returns a `Link` header pointing agents to the API catalog, OpenAPI description, `llms.txt`, sitemap, and agent-skills index
- **Content Signals** — `robots.txt` declares `Content-Signal: search=yes, ai-input=yes, ai-train=no` (allow indexing + AI answers, disallow model training)
- **RFC 9727 API catalog** — `/.well-known/api-catalog` returns `application/linkset+json`; `/.well-known/openapi.json` is the companion OpenAPI 3.1 description
- **Public menus API** — new `GET /api/menus` and `/api/menus/[uid]` (CORS-open, read-only) backed by the existing menu JSON files
- **Markdown for Agents** — `Accept: text/markdown` on any supported page is content-negotiated to a Markdown rendering (`Content-Type: text/markdown` + `x-markdown-tokens`); menus render from JSON, FAQ from content, homepage/key pages from structured facts
- **Agent Skills index** — `/.well-known/agent-skills/index.json` (v0.2.0) with 3 genuine SKILL.md files and sha256 digests (`venue-info`, `browse-menus`, `submit-inquiry`)
- **WebMCP** — feature-detected `navigator.modelContext` tools (venue info, menus, inquiry); progressive enhancement, no-op in browsers that don't support it
- **DNS-AID docs** — `docs/dns-aid.md` documents the SVCB/HTTPS + DNSSEC records to publish at the DNS provider (can't live in the repo)

## What was intentionally omitted

OAuth/OIDC discovery, OAuth Protected Resource Metadata, Auth.md, and the MCP Server Card were all skipped — the site has no backing OAuth or MCP server, and publishing those endpoints would advertise services that don't exist.

The **health API is not advertised** anywhere (not in the catalog, OpenAPI, robots.txt, or llms.txt). The endpoint continues to exist for internal use.

## Test plan

- [ ] Build passes (`pnpm build`) and all 11 unit tests pass (`pnpm test:unit`)
- [ ] `curl -I https://thegrandlb.com/` returns a `Link:` header containing `rel="api-catalog"`
- [ ] `curl https://thegrandlb.com/.well-known/api-catalog` returns `Content-Type: application/linkset+json`
- [ ] `curl https://thegrandlb.com/.well-known/openapi.json` returns `Content-Type: application/json`
- [ ] `curl https://thegrandlb.com/.well-known/agent-skills/index.json` returns the skills index
- [ ] `curl https://thegrandlb.com/api/menus` returns the 4-menu catalog
- [ ] `curl https://thegrandlb.com/api/menus/classic` returns menu content
- [ ] `curl -H "Accept: text/markdown" https://thegrandlb.com/menus/classic` returns `Content-Type: text/markdown` with `# Our Classic Menu` as the first line
- [ ] `curl -H "Accept: text/markdown" https://thegrandlb.com/faq` returns `# Frequently Asked Questions`
- [ ] `curl https://thegrandlb.com/robots.txt` contains `Content-Signal: search=yes, ai-input=yes, ai-train=no`

https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo)_