### PR TITLE
feat: track agent endpoint usage via Vercel Analytics

### DIFF
--- a/src/app/(site)/api/mcp/route.ts
+++ b/src/app/(site)/api/mcp/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { SITE_ORIGIN, venueInfo } from "@/lib/agent/site-info";
+import { track } from "@vercel/analytics/server";
 
 const PROTOCOL_VERSION = "2024-11-05";
 
@@ -138,6 +139,7 @@ export async function POST(request: NextRequest) {
       const toolName = String(p.name ?? "");
       const toolArgs = (p.arguments ?? {}) as Record<string, unknown>;
       try {
+        await track("agent.mcp.tool_call", { tool: toolName });
         const result = await callTool(toolName, toolArgs);
         return ok(id, {
           content: [

--- a/src/app/(site)/api/md/route.ts
+++ b/src/app/(site)/api/md/route.ts
@@ -1,5 +1,6 @@
 import { buildPageMarkdown } from "@/lib/agent/page-markdown";
 import type { NextRequest } from "next/server";
+import { track } from "@vercel/analytics/server";
 
 /**
  * Markdown-for-agents endpoint. `proxy.ts` rewrites page requests that carry
@@ -13,6 +14,7 @@ export async function GET(request: NextRequest) {
     request.headers.get("x-md-path") ??
     request.nextUrl.searchParams.get("path") ??
     "/";
+  await track("agent.markdown.request", { path });
   const markdown = await buildPageMarkdown(path);
 
   if (markdown == null) {

--- a/src/app/(site)/api/menus/[uid]/route.ts
+++ b/src/app/(site)/api/menus/[uid]/route.ts
@@ -1,6 +1,7 @@
 import { fetchMenuCollection } from "@/services/menu-data";
 import { venueInfo } from "@/lib/agent/site-info";
 import { NextResponse } from "next/server";
+import { track } from "@vercel/analytics/server";
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -18,6 +19,8 @@ export async function GET(
   { params }: { params: Promise<{ uid: string }> },
 ) {
   const { uid } = await params;
+
+  await track("agent.menus.get", { menu: uid });
 
   if (!VALID_UIDS.includes(uid)) {
     return NextResponse.json(

--- a/src/app/(site)/api/menus/route.ts
+++ b/src/app/(site)/api/menus/route.ts
@@ -1,5 +1,6 @@
 import { SITE_ORIGIN, venueInfo } from "@/lib/agent/site-info";
 import { NextResponse } from "next/server";
+import { track } from "@vercel/analytics/server";
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -18,6 +19,7 @@ const MENU_TITLES: Record<string, string> = {
  * given UID is available at `/api/menus/{uid}`.
  */
 export async function GET() {
+  await track("agent.menus.list");
   const menus = venueInfo.catering.menuUids.map((uid) => ({
     uid,
     title: MENU_TITLES[uid] ?? uid,


### PR DESCRIPTION
## Summary

- Adds `track()` calls (from `@vercel/analytics/server`) to the four agent-facing endpoints
- Events appear in Vercel Dashboard → Analytics → Custom Events

| Event | Properties |
|-------|-----------|
| `agent.menus.list` | — |
| `agent.menus.get` | `menu: "weddings"` |
| `agent.markdown.request` | `path: "/faq"` |
| `agent.mcp.tool_call` | `tool: "get_venue_info"` |

## Test plan

- [ ] Merge and deploy
- [ ] Hit `/api/menus`, `/api/menus/weddings`, and `POST /api/mcp` with a `tools/call`
- [ ] Confirm events appear in Vercel Analytics → Custom Events within a few minutes

https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo)_