### PR TITLE
feat: track conversion points via Vercel Analytics

### DIFF
--- a/src/components/AppLink.tsx
+++ b/src/components/AppLink.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { LinkField } from "content/types";
+import { track } from "@vercel/analytics";
 import Link from "next/link";
 import React from "react";
 
@@ -95,6 +96,14 @@ const AppLink = React.forwardRef<HTMLAnchorElement, AppLinkProps>(
 
     if (isExternal) {
       const target = (field as any)?.target || rest.target || "_blank";
+      const handleExternalClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        if (resolvedUrl?.startsWith("tel:")) {
+          track("conversion.phone_click", { number: resolvedUrl.replace("tel:", "") });
+        } else if (resolvedUrl?.startsWith("mailto:")) {
+          track("engagement.email_click", { address: resolvedUrl.replace("mailto:", "") });
+        }
+        rest.onClick?.(e);
+      };
       return (
         <a
           ref={ref}
@@ -102,6 +111,7 @@ const AppLink = React.forwardRef<HTMLAnchorElement, AppLinkProps>(
           target={target}
           rel="noopener noreferrer"
           {...rest}
+          onClick={handleExternalClick}
         >
           {children}
         </a>

--- a/src/components/form/InquireFormContainer.tsx
+++ b/src/components/form/InquireFormContainer.tsx
@@ -12,6 +12,7 @@ import {
   toastSubmitError,
   toastSubmitSuccess,
 } from "@/utils/events";
+import { track } from "@vercel/analytics";
 import {
   isValidEmail,
   validateValueWithRule,
@@ -87,6 +88,7 @@ export function InquireFormContainer() {
 
     try {
       toastSubmit();
+      track("conversion.inquiry_submit", { event_type: String(formState?.event_type?.value || "") });
 
       const {
         additional_details,
@@ -123,12 +125,14 @@ export function InquireFormContainer() {
         formState,
       });
 
+      track("conversion.inquiry_success", { event_type: String(formState?.event_type?.value || "") });
       toastSubmitSuccess();
       router.push("/thanks");
     } catch (error) {
       console.error(error);
       isSubmittingRef.current = false;
       setSubmitLoading(false);
+      track("conversion.inquiry_error");
       toastSubmitError();
     }
   };

--- a/src/components/form/InquireFormSection.tsx
+++ b/src/components/form/InquireFormSection.tsx
@@ -2,6 +2,7 @@ import { FormPage } from "@/data/form.types";
 import {
   eventInquireNext,
   eventInquirePrev,
+  eventInquireSubmit,
   toastNextError,
 } from "@/utils/events";
 import { formatDate, formatTitle } from "@/utils/utils";
@@ -153,6 +154,7 @@ export const InquireFormSection = ({
 
   const handleFormSubmitClick = () => {
     updateValidityForKeys(pageInputValues);
+    eventInquireSubmit(step);
     handleFormSubmit();
   };
 


### PR DESCRIPTION
## Summary

Three changes across the conversion funnel:

**Bug fix — inquiry submit was never tracked**
`eventInquireSubmit()` was defined in `events.ts` but never called. The submit button click was invisible to GTM and Hotjar. Now wired up in `handleFormSubmitClick()`.

**Vercel Analytics — inquiry funnel**
| Event | Properties | Trigger |
|-------|-----------|---------|
| `conversion.inquiry_submit` | `event_type` | User hits Submit |
| `conversion.inquiry_success` | `event_type` | Form POSTs successfully, redirects to /thanks |
| `conversion.inquiry_error` | — | Submission fails |

The `event_type` property (wedding, corporate, etc.) lets you see which event types convert.

**Vercel Analytics — phone & email clicks**
`AppLink` now fires on `tel:` and `mailto:` links, which were previously completely untracked:
| Event | Properties |
|-------|-----------|
| `conversion.phone_click` | `number` |
| `engagement.email_click` | `address` |

## Test plan

- [ ] Open `/inquire`, fill out the form, click Submit — confirm `conversion.inquiry_submit` appears in Vercel Analytics
- [ ] Complete a successful submission — confirm `conversion.inquiry_success` appears
- [ ] Click the phone number on `/contact` — confirm `conversion.phone_click` appears in Vercel Analytics

https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo)_