### PR TITLE
feat: analytics drain receiver and Retool-ready read API

### DIFF
--- a/public/.well-known/openapi.json
+++ b/public/.well-known/openapi.json
@@ -1,15 +1,23 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "The Grand LB Public API",
-    "version": "1.0.0",
-    "description": "Public, read-only endpoints for The Grand Long Beach event venue. No authentication is required. Use these to read catering menu data and check service health.",
+    "title": "The Grand LB API",
+    "version": "1.1.0",
+    "description": "Public and internal endpoints for The Grand Long Beach event venue. Public endpoints require no auth. Analytics endpoints require a Bearer token (set ANALYTICS_READ_TOKEN in Vercel env).",
     "contact": {
       "name": "The Grand LB",
       "url": "https://thegrandlb.com/contact"
     }
   },
   "servers": [{ "url": "https://thegrandlb.com" }],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
   "paths": {
     "/api/menus": {
       "get": {
@@ -69,6 +77,64 @@
             "content": { "application/json": { "schema": { "type": "object" } } }
           },
           "404": { "description": "Menu not found." }
+        }
+      }
+    },
+    "/api/analytics": {
+      "get": {
+        "operationId": "queryAnalytics",
+        "summary": "Query analytics events",
+        "description": "Returns analytics data from the events database. Use the `q` parameter to select which dataset to return.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Query type.",
+            "schema": {
+              "type": "string",
+              "enum": ["events", "event_counts", "daily", "inquiry_funnel", "agent_activity", "phone_clicks"],
+              "default": "events"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Lookback window in days (max 90, default 30).",
+            "schema": { "type": "integer", "default": 30 }
+          },
+          {
+            "name": "event_name",
+            "in": "query",
+            "required": false,
+            "description": "Filter by event name (used with q=events and q=daily).",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max rows to return for q=events (max 500, default 100).",
+            "schema": { "type": "integer", "default": 100 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Query results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rows": { "type": "array", "items": { "type": "object" } }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid Bearer token." }
         }
       }
     }

--- a/src/app/(site)/api/analytics-drain/route.ts
+++ b/src/app/(site)/api/analytics-drain/route.ts
@@ -1,0 +1,102 @@
+import type { NextRequest } from "next/server";
+import pool from "../../../../services/db";
+
+// Vercel signs drain payloads with HMAC-SHA1 using the drain secret.
+// Set ANALYTICS_DRAIN_SECRET in Vercel env vars to match what you configure
+// in the drain settings. If unset, signature verification is skipped (dev only).
+async function verifySignature(body: string, header: string | null): Promise<boolean> {
+  const secret = process.env.ANALYTICS_DRAIN_SECRET;
+  if (!secret) return true; // skip in dev
+  if (!header) return false;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-1" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  const expected = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return header === `sha1=${expected}`;
+}
+
+const SETUP_SQL = `
+  CREATE TABLE IF NOT EXISTS analytics_events (
+    id          BIGSERIAL PRIMARY KEY,
+    event_type  TEXT        NOT NULL,
+    event_name  TEXT,
+    event_data  JSONB,
+    path        TEXT,
+    origin      TEXT,
+    session_id  BIGINT,
+    device_id   BIGINT,
+    project_id  TEXT,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+  CREATE INDEX IF NOT EXISTS analytics_events_event_name_idx  ON analytics_events (event_name);
+  CREATE INDEX IF NOT EXISTS analytics_events_occurred_at_idx ON analytics_events (occurred_at DESC);
+`;
+
+let tableReady = false;
+
+async function ensureTable() {
+  if (tableReady) return;
+  await pool.query(SETUP_SQL);
+  tableReady = true;
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+
+  const valid = await verifySignature(body, request.headers.get("x-vercel-signature"));
+  if (!valid) return new Response("Unauthorized", { status: 401 });
+
+  // Vercel sends either NDJSON (one object per line) or a JSON array
+  let events: unknown[];
+  try {
+    const trimmed = body.trim();
+    events = trimmed.startsWith("[") ? JSON.parse(trimmed) : trimmed.split("\n").map((l) => JSON.parse(l));
+  } catch {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  await ensureTable();
+
+  const analyticsEvents = (events as Record<string, unknown>[]).filter(
+    (e) => e.schema === "vercel.analytics.v2",
+  );
+
+  if (analyticsEvents.length === 0) return new Response(null, { status: 204 });
+
+  const values = analyticsEvents.map((e) => [
+    String(e.eventType ?? ""),
+    e.eventName ? String(e.eventName) : null,
+    e.eventData ? (typeof e.eventData === "string" ? JSON.parse(e.eventData) : e.eventData) : null,
+    e.path ? String(e.path) : null,
+    e.origin ? String(e.origin) : null,
+    e.sessionId ?? null,
+    e.deviceId ?? null,
+    e.projectId ? String(e.projectId) : null,
+    new Date(Number(e.timestamp)).toISOString(),
+  ]);
+
+  const placeholders = values
+    .map((_, i) => {
+      const base = i * 9;
+      return `($${base + 1},$${base + 2},$${base + 3},$${base + 4},$${base + 5},$${base + 6},$${base + 7},$${base + 8},$${base + 9})`;
+    })
+    .join(",");
+
+  await pool.query(
+    `INSERT INTO analytics_events
+       (event_type,event_name,event_data,path,origin,session_id,device_id,project_id,occurred_at)
+     VALUES ${placeholders}`,
+    values.flat(),
+  );
+
+  return new Response(null, { status: 204 });
+}

--- a/src/app/(site)/api/analytics/route.ts
+++ b/src/app/(site)/api/analytics/route.ts
@@ -1,11 +1,11 @@
 import type { NextRequest } from "next/server";
 import pool from "../../../../services/db";
 
-// Simple token auth — set ANALYTICS_READ_TOKEN in Vercel env vars,
-// then use that as the Bearer token in Retool's REST resource.
+// Bearer token auth — ANALYTICS_READ_TOKEN must be set in Vercel env vars.
+// Use the same token as the Bearer value in Retool's REST resource headers.
 function isAuthorized(request: NextRequest): boolean {
   const token = process.env.ANALYTICS_READ_TOKEN;
-  if (!token) return true; // open in dev if not set
+  if (!token) return false; // deny if token not configured
   const auth = request.headers.get("authorization") ?? "";
   return auth === `Bearer ${token}`;
 }

--- a/src/app/(site)/api/analytics/route.ts
+++ b/src/app/(site)/api/analytics/route.ts
@@ -1,0 +1,137 @@
+import type { NextRequest } from "next/server";
+import pool from "../../../../services/db";
+
+// Simple token auth — set ANALYTICS_READ_TOKEN in Vercel env vars,
+// then use that as the Bearer token in Retool's REST resource.
+function isAuthorized(request: NextRequest): boolean {
+  const token = process.env.ANALYTICS_READ_TOKEN;
+  if (!token) return true; // open in dev if not set
+  const auth = request.headers.get("authorization") ?? "";
+  return auth === `Bearer ${token}`;
+}
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type",
+};
+
+export function OPTIONS() {
+  return new Response(null, { status: 204, headers: CORS });
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401, headers: CORS });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const endpoint = searchParams.get("q") ?? "events";
+  const days = Math.min(parseInt(searchParams.get("days") ?? "30"), 90);
+  const since = `NOW() - INTERVAL '${days} days'`;
+
+  try {
+    let result;
+
+    switch (endpoint) {
+      // Recent raw events — used for the event log table in Retool
+      case "events": {
+        const limit = Math.min(parseInt(searchParams.get("limit") ?? "100"), 500);
+        const eventName = searchParams.get("event_name");
+        const where = eventName ? `AND event_name = $2` : "";
+        const params: unknown[] = [limit];
+        if (eventName) params.push(eventName);
+        result = await pool.query(
+          `SELECT id, event_type, event_name, event_data, path, occurred_at
+           FROM analytics_events
+           WHERE occurred_at > ${since} ${where}
+           ORDER BY occurred_at DESC
+           LIMIT $1`,
+          params,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Event counts grouped by name — for the bar/pie chart
+      case "event_counts": {
+        result = await pool.query(
+          `SELECT event_name, COUNT(*)::int AS count
+           FROM analytics_events
+           WHERE occurred_at > ${since} AND event_name IS NOT NULL
+           GROUP BY event_name
+           ORDER BY count DESC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Daily event volume — for the time-series chart
+      case "daily": {
+        const eventName = searchParams.get("event_name");
+        const where = eventName ? `AND event_name = $1` : "";
+        const params = eventName ? [eventName] : [];
+        result = await pool.query(
+          `SELECT DATE(occurred_at) AS date, COUNT(*)::int AS count
+           FROM analytics_events
+           WHERE occurred_at > ${since} ${where}
+           GROUP BY DATE(occurred_at)
+           ORDER BY date ASC`,
+          params,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Inquiry funnel: submit → success rate
+      case "inquiry_funnel": {
+        result = await pool.query(
+          `SELECT
+             event_name,
+             COUNT(*)::int AS total,
+             event_data->>'event_type' AS event_type
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+             AND event_name IN ('conversion.inquiry_submit','conversion.inquiry_success','conversion.inquiry_error')
+           GROUP BY event_name, event_data->>'event_type'
+           ORDER BY event_name, total DESC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Agent activity: MCP tool calls + menu fetches + markdown requests
+      case "agent_activity": {
+        result = await pool.query(
+          `SELECT
+             event_name,
+             event_data->>'tool'  AS tool,
+             event_data->>'menu'  AS menu,
+             event_data->>'path'  AS md_path,
+             COUNT(*)::int        AS count
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+             AND event_name LIKE 'agent.%'
+           GROUP BY event_name, event_data->>'tool', event_data->>'menu', event_data->>'path'
+           ORDER BY count DESC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Phone click counts
+      case "phone_clicks": {
+        result = await pool.query(
+          `SELECT DATE(occurred_at) AS date, COUNT(*)::int AS count
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+             AND event_name = 'conversion.phone_click'
+           GROUP BY DATE(occurred_at)
+           ORDER BY date ASC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      default:
+        return Response.json({ error: "Unknown query" }, { status: 400, headers: CORS });
+    }
+  } catch (err) {
+    console.error("[analytics]", err);
+    return Response.json({ error: "Query failed" }, { status: 500, headers: CORS });
+  }
+}


### PR DESCRIPTION
## Summary

- **`/api/analytics-drain`** — receives Vercel Analytics Drain NDJSON payloads, verifies HMAC-SHA1 signature, auto-creates `analytics_events` table on first request, bulk-inserts events into Postgres
- **`/api/analytics`** — authenticated read API (requires `Bearer ANALYTICS_READ_TOKEN`) with six query types for Retool dashboards
- **`openapi.json`** — updated to v1.1.0 with full `/api/analytics` parameter and response schema for Retool import

## Security

`/api/analytics` returns **401 if `ANALYTICS_READ_TOKEN` is not set** — no open fallback. Set the token in Vercel env vars before deploying.

## Query types (`?q=`)

| Value | Returns |
|-------|---------|
| `events` | Recent raw events log |
| `event_counts` | Counts grouped by event name |
| `daily` | Daily volume time series |
| `inquiry_funnel` | submit → success → error by event type |
| `agent_activity` | MCP tool calls, menu fetches, markdown requests |
| `phone_clicks` | Daily phone click counts |

## Setup after merge

**1. Add env vars in Vercel:**
- `ANALYTICS_DRAIN_SECRET` — copy from the drain you create in step 2
- `ANALYTICS_READ_TOKEN` — generate a strong random string (e.g. `openssl rand -hex 32`)

**2. Configure the Vercel Analytics Drain:**
- Vercel Dashboard → Project → Settings → Log Drains → Add Drain
- URL: `https://thegrandlb.com/api/analytics-drain`
- Sources: check **Web Analytics**
- Copy the generated secret → paste as `ANALYTICS_DRAIN_SECRET`

**3. Connect Retool:**
- Resources → Create → REST API
- Base URL: `https://thegrandlb.com`
- Header: `Authorization: Bearer <your ANALYTICS_READ_TOKEN>`
- Or import `https://thegrandlb.com/.well-known/openapi.json` directly

## Test plan

- [ ] Set env vars, deploy
- [ ] Hit `/api/analytics?q=events` without token → 401
- [ ] Hit with correct Bearer token → `{ rows: [] }` (empty until drain delivers events)
- [ ] Configure drain in Vercel, trigger some page views, confirm rows appear

https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo)_