### PR TITLE
fix: drain signature verification returning 401 on every delivery

### DIFF
--- a/src/app/(site)/api/analytics-drain/route.ts
+++ b/src/app/(site)/api/analytics-drain/route.ts
@@ -1,26 +1,26 @@
+import crypto from "node:crypto";
 import type { NextRequest } from "next/server";
 import pool from "../../../../services/db";
 
-// Vercel signs drain payloads with HMAC-SHA1 using the drain secret.
-// Set ANALYTICS_DRAIN_SECRET in Vercel env vars to match what you configure
-// in the drain settings. If unset, signature verification is skipped (dev only).
-async function verifySignature(body: string, header: string | null): Promise<boolean> {
+// Vercel signs each drain delivery with HMAC-SHA1 over the raw request body,
+// using the drain's signing secret, and sends the result as a bare hex digest
+// in the `x-vercel-signature` header (no "sha1=" prefix). Set
+// ANALYTICS_DRAIN_SECRET to that signing secret. Fails closed if it is unset.
+function verifySignature(rawBody: string, header: string | null): boolean {
   const secret = process.env.ANALYTICS_DRAIN_SECRET;
-  if (!secret) return true; // skip in dev
-  if (!header) return false;
+  if (!secret || !header) return false;
 
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-1" },
-    false,
-    ["sign"],
+  const expected = crypto
+    .createHmac("sha1", secret)
+    .update(rawBody, "utf-8")
+    .digest("hex");
+
+  const received = Buffer.from(header);
+  const computed = Buffer.from(expected);
+  return (
+    received.length === computed.length &&
+    crypto.timingSafeEqual(received, computed)
   );
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
-  const expected = Array.from(new Uint8Array(sig))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return header === `sha1=${expected}`;
 }
 
 const SETUP_SQL = `
@@ -52,7 +52,7 @@ async function ensureTable() {
 export async function POST(request: NextRequest) {
   const body = await request.text();
 
-  const valid = await verifySignature(body, request.headers.get("x-vercel-signature"));
+  const valid = verifySignature(body, request.headers.get("x-vercel-signature"));
   if (!valid) return new Response("Unauthorized", { status: 401 });
 
   // Vercel sends either NDJSON (one object per line) or a JSON array


### PR DESCRIPTION
## Problem

Every Vercel Analytics Drain delivery to `/api/analytics-drain` returns **401**, so no real events reach the database:

```
POST /api/analytics-drain → 401
User Agent: VercelDrain/1.0
```

## Root cause

Vercel sends `x-vercel-signature` as a **bare hex** HMAC-SHA1 digest (e.g. `a1b2c3…`), but the receiver compared it against `` `sha1=${expected}` `` — a prefix Vercel never sends. The comparison could never match even with the correct secret.

## Fix

- Switch to `node:crypto`, mirroring [Vercel's reference verifier](https://vercel.com/docs/drains/security)
- Compare against the **bare hex** digest (no `sha1=` prefix)
- Use `crypto.timingSafeEqual` for a constant-time comparison
- **Fail closed** when `ANALYTICS_DRAIN_SECRET` is unset (removes the old dev-skip that accepted unsigned payloads)

## After merge

1. Confirm `ANALYTICS_DRAIN_SECRET` in Vercel **exactly** matches the drain's signing secret (Vercel → Settings → Drains → your drain)
2. Use Vercel's **Test** button on the drain — receiver should now return `204`
3. Real `pageview` + custom `agent.*` / `conversion.*` events will begin landing in `analytics_events`

Note: the ~3 `/test-page` pageview rows already in the table are Vercel's synthetic test-drain payload that got inserted while the secret was unset (old code accepted unsigned deliveries). Safe to delete.

https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYnxhu2wQ1gJsMR3ThXFNo)_