### PR TITLE
Capture richer analytics dimensions (device, source, geo, UTM)

### DIFF
--- a/src/app/(site)/api/analytics-drain/route.ts
+++ b/src/app/(site)/api/analytics-drain/route.ts
@@ -23,6 +23,50 @@ function verifySignature(rawBody: string, header: string | null): boolean {
   );
 }
 
+// Columns written for every event, in insert order. `event_type` and
+// `occurred_at` are required; everything else is nullable. `raw` keeps the full
+// Vercel event so we never silently drop a field again — new dimensions can be
+// backfilled from it without re-instrumenting the site.
+const COLUMNS = [
+  "event_type",
+  "event_name",
+  "event_data",
+  "path",
+  "route",
+  "origin",
+  "referrer",
+  "referrer_host",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "country",
+  "region",
+  "city",
+  "device_type",
+  "device_brand",
+  "device_model",
+  "os_name",
+  "os_version",
+  "browser_name",
+  "browser_version",
+  "client_type",
+  "session_id",
+  "device_id",
+  "project_id",
+  "owner_id",
+  "vercel_env",
+  "deployment_id",
+  "raw",
+  "occurred_at",
+] as const;
+
+type Column = (typeof COLUMNS)[number];
+
+// The base table predates the richer dimensions, so we add the new columns with
+// idempotent, additive `ADD COLUMN IF NOT EXISTS` — safe to run against the
+// existing populated table on every cold start.
 const SETUP_SQL = `
   CREATE TABLE IF NOT EXISTS analytics_events (
     id          BIGSERIAL PRIMARY KEY,
@@ -37,8 +81,36 @@ const SETUP_SQL = `
     occurred_at TIMESTAMPTZ NOT NULL,
     received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
   );
-  CREATE INDEX IF NOT EXISTS analytics_events_event_name_idx  ON analytics_events (event_name);
-  CREATE INDEX IF NOT EXISTS analytics_events_occurred_at_idx ON analytics_events (occurred_at DESC);
+  ALTER TABLE analytics_events
+    ADD COLUMN IF NOT EXISTS route           TEXT,
+    ADD COLUMN IF NOT EXISTS referrer        TEXT,
+    ADD COLUMN IF NOT EXISTS referrer_host   TEXT,
+    ADD COLUMN IF NOT EXISTS utm_source      TEXT,
+    ADD COLUMN IF NOT EXISTS utm_medium      TEXT,
+    ADD COLUMN IF NOT EXISTS utm_campaign    TEXT,
+    ADD COLUMN IF NOT EXISTS utm_term        TEXT,
+    ADD COLUMN IF NOT EXISTS utm_content     TEXT,
+    ADD COLUMN IF NOT EXISTS country         TEXT,
+    ADD COLUMN IF NOT EXISTS region          TEXT,
+    ADD COLUMN IF NOT EXISTS city            TEXT,
+    ADD COLUMN IF NOT EXISTS device_type     TEXT,
+    ADD COLUMN IF NOT EXISTS device_brand    TEXT,
+    ADD COLUMN IF NOT EXISTS device_model    TEXT,
+    ADD COLUMN IF NOT EXISTS os_name         TEXT,
+    ADD COLUMN IF NOT EXISTS os_version      TEXT,
+    ADD COLUMN IF NOT EXISTS browser_name    TEXT,
+    ADD COLUMN IF NOT EXISTS browser_version TEXT,
+    ADD COLUMN IF NOT EXISTS client_type     TEXT,
+    ADD COLUMN IF NOT EXISTS owner_id        TEXT,
+    ADD COLUMN IF NOT EXISTS vercel_env      TEXT,
+    ADD COLUMN IF NOT EXISTS deployment_id   TEXT,
+    ADD COLUMN IF NOT EXISTS raw             JSONB;
+  CREATE INDEX IF NOT EXISTS analytics_events_event_name_idx    ON analytics_events (event_name);
+  CREATE INDEX IF NOT EXISTS analytics_events_occurred_at_idx   ON analytics_events (occurred_at DESC);
+  CREATE INDEX IF NOT EXISTS analytics_events_device_type_idx   ON analytics_events (device_type);
+  CREATE INDEX IF NOT EXISTS analytics_events_country_idx       ON analytics_events (country);
+  CREATE INDEX IF NOT EXISTS analytics_events_referrer_host_idx ON analytics_events (referrer_host);
+  CREATE INDEX IF NOT EXISTS analytics_events_utm_source_idx    ON analytics_events (utm_source);
 `;
 
 let tableReady = false;
@@ -49,17 +121,119 @@ async function ensureTable() {
   tableReady = true;
 }
 
+// Normalize empty/missing values to null so dimension GROUP BYs stay clean.
+function str(v: unknown): string | null {
+  return v === undefined || v === null || v === "" ? null : String(v);
+}
+
+// Bare hostname (sans leading www.) for referrer grouping, e.g.
+// "https://www.google.com/search" -> "google.com".
+function hostOf(url: unknown): string | null {
+  const s = str(url);
+  if (!s) return null;
+  try {
+    return new URL(s).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+const UTM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+] as const;
+
+// Vercel sends the raw query string in `queryParams`; pull the standard UTM
+// fields out into their own columns for acquisition reporting.
+function parseUtm(
+  queryParams: unknown,
+): Record<(typeof UTM_KEYS)[number], string | null> {
+  const out = {
+    utm_source: null,
+    utm_medium: null,
+    utm_campaign: null,
+    utm_term: null,
+    utm_content: null,
+  } as Record<(typeof UTM_KEYS)[number], string | null>;
+  const s = str(queryParams);
+  if (!s) return out;
+  try {
+    const params = new URLSearchParams(s.startsWith("?") ? s.slice(1) : s);
+    for (const k of UTM_KEYS) {
+      const v = params.get(k);
+      if (v) out[k] = v;
+    }
+  } catch {
+    /* ignore malformed query strings */
+  }
+  return out;
+}
+
+// jsonb params must be passed as JSON text; objects/arrays are stringified so
+// node-postgres doesn't coerce arrays into Postgres array literals.
+function asJsonb(v: unknown): string | null {
+  if (v === undefined || v === null) return null;
+  return typeof v === "string" ? v : JSON.stringify(v);
+}
+
+function rowFor(e: Record<string, unknown>): unknown[] {
+  const utm = parseUtm(e.queryParams);
+  const values: Record<Column, unknown> = {
+    event_type: String(e.eventType ?? ""),
+    event_name: str(e.eventName),
+    event_data: asJsonb(e.eventData),
+    path: str(e.path),
+    route: str(e.route),
+    origin: str(e.origin),
+    referrer: str(e.referrer),
+    referrer_host: hostOf(e.referrer),
+    utm_source: utm.utm_source,
+    utm_medium: utm.utm_medium,
+    utm_campaign: utm.utm_campaign,
+    utm_term: utm.utm_term,
+    utm_content: utm.utm_content,
+    country: str(e.country),
+    region: str(e.region),
+    city: str(e.city),
+    device_type: str(e.deviceType),
+    device_brand: str(e.deviceBrand),
+    device_model: str(e.deviceModel),
+    os_name: str(e.osName),
+    os_version: str(e.osVersion),
+    browser_name: str(e.clientName),
+    browser_version: str(e.clientVersion),
+    client_type: str(e.clientType),
+    session_id: e.sessionId ?? null,
+    device_id: e.deviceId ?? null,
+    project_id: str(e.projectId),
+    owner_id: str(e.ownerId),
+    vercel_env: str(e.vercelEnvironment),
+    deployment_id: str(e.deployment),
+    raw: asJsonb(e),
+    occurred_at: new Date(Number(e.timestamp)).toISOString(),
+  };
+  return COLUMNS.map((c) => values[c]);
+}
+
 export async function POST(request: NextRequest) {
   const body = await request.text();
 
-  const valid = verifySignature(body, request.headers.get("x-vercel-signature"));
+  const valid = verifySignature(
+    body,
+    request.headers.get("x-vercel-signature"),
+  );
   if (!valid) return new Response("Unauthorized", { status: 401 });
 
   // Vercel sends either NDJSON (one object per line) or a JSON array
   let events: unknown[];
   try {
     const trimmed = body.trim();
-    events = trimmed.startsWith("[") ? JSON.parse(trimmed) : trimmed.split("\n").map((l) => JSON.parse(l));
+    events = trimmed.startsWith("[")
+      ? JSON.parse(trimmed)
+      : trimmed.split("\n").map((l: string) => JSON.parse(l));
   } catch {
     return new Response("Bad Request", { status: 400 });
   }
@@ -72,30 +246,19 @@ export async function POST(request: NextRequest) {
 
   if (analyticsEvents.length === 0) return new Response(null, { status: 204 });
 
-  const values = analyticsEvents.map((e) => [
-    String(e.eventType ?? ""),
-    e.eventName ? String(e.eventName) : null,
-    e.eventData ? (typeof e.eventData === "string" ? JSON.parse(e.eventData) : e.eventData) : null,
-    e.path ? String(e.path) : null,
-    e.origin ? String(e.origin) : null,
-    e.sessionId ?? null,
-    e.deviceId ?? null,
-    e.projectId ? String(e.projectId) : null,
-    new Date(Number(e.timestamp)).toISOString(),
-  ]);
-
-  const placeholders = values
+  const rows = analyticsEvents.map(rowFor);
+  const width = COLUMNS.length;
+  const placeholders = rows
     .map((_, i) => {
-      const base = i * 9;
-      return `($${base + 1},$${base + 2},$${base + 3},$${base + 4},$${base + 5},$${base + 6},$${base + 7},$${base + 8},$${base + 9})`;
+      const base = i * width;
+      return `(${COLUMNS.map((__, j) => `$${base + j + 1}`).join(",")})`;
     })
     .join(",");
 
   await pool.query(
-    `INSERT INTO analytics_events
-       (event_type,event_name,event_data,path,origin,session_id,device_id,project_id,occurred_at)
+    `INSERT INTO analytics_events (${COLUMNS.join(",")})
      VALUES ${placeholders}`,
-    values.flat(),
+    rows.flat(),
   );
 
   return new Response(null, { status: 204 });

--- a/src/app/(site)/api/analytics/route.ts
+++ b/src/app/(site)/api/analytics/route.ts
@@ -22,7 +22,10 @@ export function OPTIONS() {
 
 export async function GET(request: NextRequest) {
   if (!isAuthorized(request)) {
-    return Response.json({ error: "Unauthorized" }, { status: 401, headers: CORS });
+    return Response.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: CORS },
+    );
   }
 
   const { searchParams } = request.nextUrl;
@@ -36,13 +39,18 @@ export async function GET(request: NextRequest) {
     switch (endpoint) {
       // Recent raw events — used for the event log table in Retool
       case "events": {
-        const limit = Math.min(parseInt(searchParams.get("limit") ?? "100"), 500);
+        const limit = Math.min(
+          parseInt(searchParams.get("limit") ?? "100"),
+          500,
+        );
         const eventName = searchParams.get("event_name");
         const where = eventName ? `AND event_name = $2` : "";
         const params: unknown[] = [limit];
         if (eventName) params.push(eventName);
         result = await pool.query(
-          `SELECT id, event_type, event_name, event_data, path, occurred_at
+          `SELECT id, event_type, event_name, event_data, path, route,
+                  referrer_host, utm_source, country, region, city,
+                  device_type, os_name, browser_name, occurred_at
            FROM analytics_events
            WHERE occurred_at > ${since} ${where}
            ORDER BY occurred_at DESC
@@ -127,11 +135,106 @@ export async function GET(request: NextRequest) {
         return Response.json({ rows: result.rows }, { headers: CORS });
       }
 
+      // Device-type mix (desktop / mobile / tablet) — pie/donut
+      case "by_device": {
+        result = await pool.query(
+          `SELECT COALESCE(device_type, 'unknown') AS device_type,
+                  COUNT(*)::int                     AS count,
+                  COUNT(DISTINCT session_id)::int   AS sessions
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+           GROUP BY COALESCE(device_type, 'unknown')
+           ORDER BY count DESC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Browser breakdown
+      case "by_browser": {
+        result = await pool.query(
+          `SELECT COALESCE(browser_name, 'unknown') AS browser_name,
+                  COUNT(*)::int                      AS count,
+                  COUNT(DISTINCT session_id)::int    AS sessions
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+           GROUP BY COALESCE(browser_name, 'unknown')
+           ORDER BY count DESC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Operating-system breakdown
+      case "by_os": {
+        result = await pool.query(
+          `SELECT COALESCE(os_name, 'unknown') AS os_name,
+                  COUNT(*)::int                 AS count,
+                  COUNT(DISTINCT session_id)::int AS sessions
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+           GROUP BY COALESCE(os_name, 'unknown')
+           ORDER BY count DESC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Acquisition sources: UTM source wins, else referrer host, else Direct
+      case "sources": {
+        result = await pool.query(
+          `SELECT COALESCE(utm_source, referrer_host, 'Direct') AS source,
+                  COUNT(*)::int                                 AS count,
+                  COUNT(DISTINCT session_id)::int               AS sessions
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+           GROUP BY COALESCE(utm_source, referrer_host, 'Direct')
+           ORDER BY count DESC
+           LIMIT 25`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // UTM campaign breakdown — only rows that carry a UTM tag
+      case "utm": {
+        result = await pool.query(
+          `SELECT utm_source, utm_medium, utm_campaign,
+                  COUNT(*)::int                   AS count,
+                  COUNT(DISTINCT session_id)::int AS sessions
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+             AND (utm_source IS NOT NULL OR utm_medium IS NOT NULL OR utm_campaign IS NOT NULL)
+           GROUP BY utm_source, utm_medium, utm_campaign
+           ORDER BY count DESC`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
+      // Geography: country (with region/city rollup)
+      case "geo": {
+        result = await pool.query(
+          `SELECT COALESCE(country, 'Unknown')  AS country,
+                  region,
+                  city,
+                  COUNT(*)::int                  AS count,
+                  COUNT(DISTINCT session_id)::int AS sessions
+           FROM analytics_events
+           WHERE occurred_at > ${since}
+           GROUP BY COALESCE(country, 'Unknown'), region, city
+           ORDER BY count DESC
+           LIMIT 100`,
+        );
+        return Response.json({ rows: result.rows }, { headers: CORS });
+      }
+
       default:
-        return Response.json({ error: "Unknown query" }, { status: 400, headers: CORS });
+        return Response.json(
+          { error: "Unknown query" },
+          { status: 400, headers: CORS },
+        );
     }
   } catch (err) {
     console.error("[analytics]", err);
-    return Response.json({ error: "Query failed" }, { status: 500, headers: CORS });
+    return Response.json(
+      { error: "Query failed" },
+      { status: 500, headers: CORS },
+    );
   }
 }


### PR DESCRIPTION
## What & why

The Vercel Web Analytics drain already sends device, browser/OS, referrer, geo and UTM fields on every event (`vercel.analytics.v2` schema), but the ingestion route was discarding everything except path/origin/ids. This persists those dimensions and exposes them through the read API so the Retool dashboard can segment by them.

No client-side instrumentation was needed — Vercel attaches these automatically.

## Changes

**`api/analytics-drain` (ingestion)**
- Adds idempotent, additive columns to `analytics_events` via `ADD COLUMN IF NOT EXISTS` (safe against the existing populated table; runs on the first drain POST after deploy):
  - Device: `device_type`, `device_brand`, `device_model`
  - Browser/OS: `browser_name`, `browser_version`, `client_type`, `os_name`, `os_version`
  - Source: `referrer`, derived `referrer_host`, `utm_source/medium/campaign/term/content` (parsed from `queryParams`)
  - Geo: `country`, `region`, `city`
  - Context: `route`, `vercel_env`, `deployment_id`, `owner_id`
  - `raw` JSONB — the full event, so no field is ever silently dropped again (future dimensions can be backfilled from it)
- New indexes on `device_type`, `country`, `referrer_host`, `utm_source`.

**`api/analytics` (read API)**
- New `q` values: `by_device`, `by_browser`, `by_os`, `sources`, `utm`, `geo` (each returns counts + distinct sessions).
- The `events` log now also returns `route, referrer_host, utm_source, country, region, city, device_type, os_name, browser_name`.

## Notes

- **Forward-only:** new dimensions populate for events recorded *after* deploy; pre-existing rows stay null (read as "unknown"/"Direct"/"Unknown").
- **No manual migration:** schema self-upgrades on the first drain delivery after deploy.
- `tsc --noEmit` passes clean across the repo.

The Retool "Custom Analytics Dashboard" has matching Audience / Acquisition / Geography panels wired to these endpoints; they activate once this is merged & deployed.

https://claude.ai/code/session_01DvViG6e7o7MDSJH3jxbKkr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvViG6e7o7MDSJH3jxbKkr)_